### PR TITLE
#36: + added secureExecute() which catches all errors in execute()

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -94,12 +94,20 @@ public class Guttenberg {
         }
 		
 		
-		executorService.scheduleAtFixedRate(()->execute(), 15, 59, TimeUnit.SECONDS);
+		executorService.scheduleAtFixedRate(()->secureExecute(), 15, 59, TimeUnit.SECONDS);
 		executorServiceCheck.scheduleAtFixedRate(()->checkLastExecution(), 3, 5, TimeUnit.MINUTES);
 		executorServiceUpdate.scheduleAtFixedRate(()->update(), 0, 30, TimeUnit.MINUTES);
 	}
 	
-	private void execute() {
+	private void secureExecute() {
+		try {
+			execute();
+		} catch (Throwable e) {
+			LOGGER.error("Error throws in execute()", e);
+		}
+	}
+	
+	private void execute() throws Throwable {
 		Instant startTime = Instant.now();
 		LOGGER.info("Executing at - "+startTime);
 		//NewAnswersFinder answersFinder = new NewAnswersFinder();

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -136,7 +136,7 @@ public class PlagFinder {
 				closestMatch = answer;
 			}
 		}
-		System.out.println("Score: "+highscore);
+		LOGGER.info("Score: "+highscore);
 		
 		this.jaroScore = highscore;
 		this.jaroAnswer = closestMatch;


### PR DESCRIPTION
Not sure if this works as expected. This is what I thought:

The schedules executor stops, when an [error or exception is not caught](http://stackoverflow.com/a/24902026/4687348). So I made `execute()` throwable and created `secureExecute()` which catches all the errors/exceptions in `execute()`. Am I right, that this will catch any uncaught `Throwable`s so that the executor service won't crash anymore?