### PR TITLE
Separate body, quotes, and code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /.DS_Store
 /properties
+/nbproject/

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.felixsfd.stackoverflow</groupId>
   <artifactId>guttenberg</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.1</version>
   <build>
     <resources>
       <resource>
@@ -61,5 +61,19 @@
       <url>https://raw.github.com/Tunaki/chatexchange/mvn-repo/</url>
     </repository>
   </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,18 @@
             <artifactId>java-string-similarity</artifactId>
             <version>0.21</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -4,10 +4,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
@@ -15,8 +13,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.apache.commons.lang.time.DateUtils;
-import org.apache.cxf.helpers.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.finders.NewAnswersFinder;
@@ -96,200 +92,200 @@ public class Guttenberg {
             /*if(room.getReply(chatroom)!=null)
                 chatroom.addEventListener(EventType.MESSAGE_REPLY, room.getReply(chatroom));*/
         }
-		
-		
-		executorService.scheduleAtFixedRate(()->secureExecute(), 15, 59, TimeUnit.SECONDS);
-		executorServiceCheck.scheduleAtFixedRate(()->checkLastExecution(), 3, 5, TimeUnit.MINUTES);
-		executorServiceUpdate.scheduleAtFixedRate(()->update(), 0, 30, TimeUnit.MINUTES);
-		executorServiceLogCleaner.scheduleAtFixedRate(()->cleanLogs(), 0, 4, TimeUnit.HOURS);
-	}
-	
-	/**
-	 * Executes `excecute()` and catches all the errors
-	 * 
-	 * @see http://stackoverflow.com/a/24902026/4687348
-	 * */
-	private void secureExecute() {
-		try {
-			execute();
-		} catch (Throwable e) {
-			LOGGER.error("Error throws in execute()", e);
-		}
-	}
-	
-	private void execute() throws Throwable {
-		Instant startTime = Instant.now();
-		LOGGER.info("Executing at - "+startTime);
-		//NewAnswersFinder answersFinder = new NewAnswersFinder();
-		
-		//Fetch recent answers / The targets
-		JsonArray recentAnswers = NewAnswersFinder.findRecentAnswers();
-		
-		//Fetch their question_ids
-		List<Integer> ids = new ArrayList<Integer>();
-		for (JsonElement answer : recentAnswers) {
-			Integer id = answer.getAsJsonObject().get("question_id").getAsInt();
-			if (!ids.contains(id))
-				ids.add(id);
-		}
-		
-		
-		//Initialize the PlagFinders
-		List<PlagFinder> plagFinders = new ArrayList<PlagFinder>();
-		
-		for (JsonElement answer : recentAnswers) {
-			PlagFinder plagFinder = new PlagFinder(answer.getAsJsonObject());
-			plagFinders.add(plagFinder);
-		}
-		
-		//fetch all /questions/ids/answers sort them later
-		
-		RelatedAnswersFinder related = new RelatedAnswersFinder(ids);
-		List<JsonObject> relatedAnswersUnsorted = related.fetchRelatedAnswers();
-		
-		if (relatedAnswersUnsorted.isEmpty()) {
-			LOGGER.warn("No related answers could be fetched. Skipping this execution...");
-			return;
-		}
-		
-		LOGGER.info("Add the answers to the PlagFinders...");
-		//add relatedAnswers to the PlagFinders
-		for (PlagFinder finder : plagFinders) {
-			Integer targetId = finder.getTargetAnswerId();
-			//System.out.println("TargetID: "+targetId);
-			
-			for (JsonObject relatedItem : relatedAnswersUnsorted) {
-				//System.out.println(relatedItem);
-				if (relatedItem.has("answer_id") && relatedItem.get("answer_id").getAsInt() != targetId) {
-					finder.relatedAnswers.add(relatedItem);
-					//System.out.println("Added answer: "+relatedItem);
-				}
-			}
-		}
-		
-		LOGGER.info("Find the duplicates...");
-		//Let PlagFinders find the best match
-		for (PlagFinder finder : plagFinders) {
-			JsonObject otherAnswer = finder.getMostSimilarAnswer();
-			double score = finder.getJaroScore();
-			if (score > 0.77) {
-				for (Room room : this.chatRooms) {
-					List<OptedInUser> pingUsersList = UserUtils.pingUserIfApplicable(score, room.getRoomId());
-					if (room.getRoomId() == 111347) {
-						SoBoticsPostPrinter printer = new SoBoticsPostPrinter();
-						String report = printer.print(finder);
-						String pings = "(";
-						for (OptedInUser user : pingUsersList) {
+        
+        
+        executorService.scheduleAtFixedRate(()->secureExecute(), 15, 59, TimeUnit.SECONDS);
+        executorServiceCheck.scheduleAtFixedRate(()->checkLastExecution(), 3, 5, TimeUnit.MINUTES);
+        executorServiceUpdate.scheduleAtFixedRate(()->update(), 0, 30, TimeUnit.MINUTES);
+        executorServiceLogCleaner.scheduleAtFixedRate(()->cleanLogs(), 0, 4, TimeUnit.HOURS);
+    }
+    
+    /**
+     * Executes `excecute()` and catches all the errors
+     * 
+     * @see http://stackoverflow.com/a/24902026/4687348
+     * */
+    private void secureExecute() {
+        try {
+            execute();
+        } catch (Throwable e) {
+            LOGGER.error("Error throws in execute()", e);
+        }
+    }
+    
+    private void execute() throws Throwable {
+        Instant startTime = Instant.now();
+        LOGGER.info("Executing at - "+startTime);
+        //NewAnswersFinder answersFinder = new NewAnswersFinder();
+        
+        //Fetch recent answers / The targets
+        JsonArray recentAnswers = NewAnswersFinder.findRecentAnswers();
+        
+        //Fetch their question_ids
+        List<Integer> ids = new ArrayList<Integer>();
+        for (JsonElement answer : recentAnswers) {
+            Integer id = answer.getAsJsonObject().get("question_id").getAsInt();
+            if (!ids.contains(id))
+                ids.add(id);
+        }
+        
+        
+        //Initialize the PlagFinders
+        List<PlagFinder> plagFinders = new ArrayList<PlagFinder>();
+        
+        for (JsonElement answer : recentAnswers) {
+            PlagFinder plagFinder = new PlagFinder(answer.getAsJsonObject());
+            plagFinders.add(plagFinder);
+        }
+        
+        //fetch all /questions/ids/answers sort them later
+        
+        RelatedAnswersFinder related = new RelatedAnswersFinder(ids);
+        List<JsonObject> relatedAnswersUnsorted = related.fetchRelatedAnswers();
+        
+        if (relatedAnswersUnsorted.isEmpty()) {
+            LOGGER.warn("No related answers could be fetched. Skipping this execution...");
+            return;
+        }
+        
+        LOGGER.info("Add the answers to the PlagFinders...");
+        //add relatedAnswers to the PlagFinders
+        for (PlagFinder finder : plagFinders) {
+            Integer targetId = finder.getTargetAnswerId();
+            //System.out.println("TargetID: "+targetId);
+            
+            for (JsonObject relatedItem : relatedAnswersUnsorted) {
+                //System.out.println(relatedItem);
+                if (relatedItem.has("answer_id") && relatedItem.get("answer_id").getAsInt() != targetId) {
+                    finder.relatedAnswers.add(relatedItem);
+                    //System.out.println("Added answer: "+relatedItem);
+                }
+            }
+        }
+        
+        LOGGER.info("Find the duplicates...");
+        //Let PlagFinders find the best match
+        for (PlagFinder finder : plagFinders) {
+            JsonObject otherAnswer = finder.getMostSimilarAnswer();
+            double score = finder.getJaroScore();
+            if (score > 0.77) {
+                for (Room room : this.chatRooms) {
+                    List<OptedInUser> pingUsersList = UserUtils.pingUserIfApplicable(score, room.getRoomId());
+                    if (room.getRoomId() == 111347) {
+                        SoBoticsPostPrinter printer = new SoBoticsPostPrinter();
+                        String report = printer.print(finder);
+                        String pings = "(";
+                        for (OptedInUser user : pingUsersList) {
                             if (!user.isWhenInRoom() || (user.isWhenInRoom() && UserUtils.checkIfUserInRoom(room, user.getUser().getUserId()))) {
                                 pings+=(" @"+user.getUser().getUsername().replace(" ",""));
                             }
                         }
-						
-						if (pings.length() > 1) {
-							report += pings + " )";
-						}
-						
-						room.send(report);
-						//room.send(printer.print(finder));
-						//LOGGER.info("Posted: "+printer.print(finder));
-						StatusUtils.numberOfReportedPosts.incrementAndGet();
-					}
-				}
-			} else {
-				//LOGGER.info("Score "+finder.getJaroScore()+" too low");
-			}
-			
-			StatusUtils.numberOfCheckedTargets.incrementAndGet();
-			
-		}
-		
-		StatusUtils.lastSucceededExecutionStarted = startTime;
-		StatusUtils.lastExecutionFinished = Instant.now();
-		LOGGER.info("Finished at - "+StatusUtils.lastExecutionFinished);
-	}
-	
-	/**
-	 * Checks when the last execution was successful. After a certain amount of time without succeeded executions, FelixSFD will be pinged.
-	 * */
-	private void checkLastExecution() {
-		if (StatusUtils.askedForHelp)
-			return;
-		
-		Instant now = Instant.now();
-		Instant lastSuccess = StatusUtils.lastExecutionFinished;
-		
-		long difference = now.getEpochSecond() - lastSuccess.getEpochSecond();
-		
-		//Instant criticalDate = now.minus(15, ChronoUnit.MINUTES);
-		
-		if (difference > 15*60) {
-			for (Room room : this.chatRooms) {
-				if (room.getRoomId() == 111347) {
-					room.send("@FelixSFD Please help me! The last successful execution finished at "+StatusUtils.lastExecutionFinished);
-					StatusUtils.askedForHelp = true;
-				}
-			}
-		}
-		
-	}
-	
-	/**
-	 * Checks for updates
-	 * */
-	private void update() {
-		LOGGER.info("Load updater...");
-		Updater updater = new Updater();
-		LOGGER.info("Check for updates...");
-		boolean update = false;
-		try {
-			update = updater.updateIfAvailable(); 
-		} catch (Exception e) {
-			LOGGER.error("Could not update", e);
-			for (Room room : this.chatRooms) {
-				if (room.getRoomId() == 111347) {
-					room.send("Automatic update failed!");
-				}
-			}
-		}
-		
-		if (update) {
-			for (Room room : this.chatRooms) {
-				if (room.getRoomId() == 111347) {
-					room.send("Rebooting for update to version "+updater.getNewVersion().get());
-				}
-				room.leave();
-			}
-			try {
-				wait(10);
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-			}
-			System.exit(0);
-		}
-		
-	}
-	
-	/**
-	 * Removed old logfiles
-	 * 
-	 * @see http://stackoverflow.com/a/15042885/4687348
-	 * */
-	private void cleanLogs() {
-		int keepLogsForDays = 3;
+                        
+                        if (pings.length() > 1) {
+                            report += pings + " )";
+                        }
+                        
+                        room.send(report);
+                        //room.send(printer.print(finder));
+                        //LOGGER.info("Posted: "+printer.print(finder));
+                        StatusUtils.numberOfReportedPosts.incrementAndGet();
+                    }
+                }
+            } else {
+                //LOGGER.info("Score "+finder.getJaroScore()+" too low");
+            }
+            
+            StatusUtils.numberOfCheckedTargets.incrementAndGet();
+            
+        }
+        
+        StatusUtils.lastSucceededExecutionStarted = startTime;
+        StatusUtils.lastExecutionFinished = Instant.now();
+        LOGGER.info("Finished at - "+StatusUtils.lastExecutionFinished);
+    }
+    
+    /**
+     * Checks when the last execution was successful. After a certain amount of time without succeeded executions, FelixSFD will be pinged.
+     * */
+    private void checkLastExecution() {
+        if (StatusUtils.askedForHelp)
+            return;
+        
+        Instant now = Instant.now();
+        Instant lastSuccess = StatusUtils.lastExecutionFinished;
+        
+        long difference = now.getEpochSecond() - lastSuccess.getEpochSecond();
+        
+        //Instant criticalDate = now.minus(15, ChronoUnit.MINUTES);
+        
+        if (difference > 15*60) {
+            for (Room room : this.chatRooms) {
+                if (room.getRoomId() == 111347) {
+                    room.send("@FelixSFD Please help me! The last successful execution finished at "+StatusUtils.lastExecutionFinished);
+                    StatusUtils.askedForHelp = true;
+                }
+            }
+        }
+        
+    }
+    
+    /**
+     * Checks for updates
+     * */
+    private void update() {
+        LOGGER.info("Load updater...");
+        Updater updater = new Updater();
+        LOGGER.info("Check for updates...");
+        boolean update = false;
+        try {
+            update = updater.updateIfAvailable(); 
+        } catch (Exception e) {
+            LOGGER.error("Could not update", e);
+            for (Room room : this.chatRooms) {
+                if (room.getRoomId() == 111347) {
+                    room.send("Automatic update failed!");
+                }
+            }
+        }
+        
+        if (update) {
+            for (Room room : this.chatRooms) {
+                if (room.getRoomId() == 111347) {
+                    room.send("Rebooting for update to version "+updater.getNewVersion().get());
+                }
+                room.leave();
+            }
+            try {
+                wait(10);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.exit(0);
+        }
+        
+    }
+    
+    /**
+     * Removed old logfiles
+     * 
+     * @see http://stackoverflow.com/a/15042885/4687348
+     * */
+    private void cleanLogs() {
+        int keepLogsForDays = 3;
         File logsDir = new File("./logs");
         
         for (File file : logsDir.listFiles()) {
-        	long diff = new Date().getTime() - file.lastModified();
+            long diff = new Date().getTime() - file.lastModified();
 
-        	if (diff > keepLogsForDays * 24 * 60 * 60 * 1000) {
-        		try {
-        			file.delete();
-        		} catch (SecurityException e) {
-        			LOGGER.error("Could not delete file", e);
-        		}
-        	}
+            if (diff > keepLogsForDays * 24 * 60 * 60 * 1000) {
+                try {
+                    file.delete();
+                } catch (SecurityException e) {
+                    LOGGER.error("Could not delete file", e);
+                }
+            }
         }
-	}
+    }
     
     public void resetExecutors() {
         executorService.shutdownNow();

--- a/src/main/java/org/sobotics/guttenberg/commands/OptIn.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/OptIn.java
@@ -13,7 +13,7 @@ import fr.tunaki.stackoverflow.chat.User;
 
 public class OptIn implements SpecialCommand {
 
-	private Message message;
+    private Message message;
 
     public OptIn(Message message) {
         this.message = message;
@@ -24,9 +24,9 @@ public class OptIn implements SpecialCommand {
         return CommandUtils.checkForCommand(message.getPlainContent(),"opt-in");
     }
 
-	@Override
-	public void execute(Room room, Guttenberg instance) {
-		User user = message.getUser();
+    @Override
+    public void execute(Room room, Guttenberg instance) {
+        User user = message.getUser();
         long userId = user.getId();
         String userName = user.getName();
         String filename = FilePathUtils.optedUsersFile;
@@ -36,50 +36,50 @@ public class OptIn implements SpecialCommand {
         String pieces[] = data.split(" ");
         
         if(pieces.length>=1){
-        	double minScore = -1;
-        	boolean whenInRoom = true;
-        	try {
-        		minScore = new Double(pieces[0]);
-        	} catch (Throwable e){
-        		room.replyTo(message.getId(), "Invalid minimum score.");
-        		return;
-        	}
-        	
-        	if (pieces.length >= 2) {
-        		if (pieces[1].equals("always")) {
-        			whenInRoom = false;
-        		}
-        	}
-        	
-        	String optMessage = userId+",\""+userName+"\""+","+room.getRoomId()+","+whenInRoom;
-        	
-        	minScore = Math.round(minScore*100.0)/100.0;
-        	
-        	try {
-				if (FileUtils.checkIfLineInFileStartsWith(filename, optMessage)) {
-					room.replyTo(message.getId(), "You've already been added");
-				} else {
-					optMessage += ","+minScore;
-					FileUtils.appendToFile(filename, optMessage);
-					room.replyTo(message.getId(), "You will be notified about possible plagiarism with a score of "+minScore+" or higher.");
-				}
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-        	
+            double minScore = -1;
+            boolean whenInRoom = true;
+            try {
+                minScore = new Double(pieces[0]);
+            } catch (Throwable e){
+                room.replyTo(message.getId(), "Invalid minimum score.");
+                return;
+            }
+            
+            if (pieces.length >= 2) {
+                if (pieces[1].equals("always")) {
+                    whenInRoom = false;
+                }
+            }
+            
+            String optMessage = userId+",\""+userName+"\""+","+room.getRoomId()+","+whenInRoom;
+            
+            minScore = Math.round(minScore*100.0)/100.0;
+            
+            try {
+                if (FileUtils.checkIfLineInFileStartsWith(filename, optMessage)) {
+                    room.replyTo(message.getId(), "You've already been added");
+                } else {
+                    optMessage += ","+minScore;
+                    FileUtils.appendToFile(filename, optMessage);
+                    room.replyTo(message.getId(), "You will be notified about possible plagiarism with a score of "+minScore+" or higher.");
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            
         } else {
-        	room.replyTo(message.getId(), "Invalid command. Correct usage: `opt-in <score> <always?>`");
+            room.replyTo(message.getId(), "Invalid command. Correct usage: `opt-in <score> <always?>`");
         }
-	}
+    }
 
-	@Override
-	public String description() {
-		return "Get notified about possible plagiarism with a certain score. Usage: `opt-in <score> <always?>`";
-	}
+    @Override
+    public String description() {
+        return "Get notified about possible plagiarism with a certain score. Usage: `opt-in <score> <always?>`";
+    }
 
-	@Override
-	public String name() {
-		return "opt-in";
-	}
+    @Override
+    public String name() {
+        return "opt-in";
+    }
 
 }

--- a/src/main/java/org/sobotics/guttenberg/commands/OptOut.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/OptOut.java
@@ -13,7 +13,7 @@ import fr.tunaki.stackoverflow.chat.User;
 
 public class OptOut implements SpecialCommand {
 
-	private Message message;
+    private Message message;
 
     public OptOut(Message message) {
         this.message = message;
@@ -24,9 +24,9 @@ public class OptOut implements SpecialCommand {
         return CommandUtils.checkForCommand(message.getPlainContent(),"opt-out");
     }
 
-	@Override
-	public void execute(Room room, Guttenberg instance) {
-		User user = message.getUser();
+    @Override
+    public void execute(Room room, Guttenberg instance) {
+        User user = message.getUser();
         long userId = user.getId();
         String userName = user.getName();
         String filename = FilePathUtils.optedUsersFile;
@@ -34,25 +34,25 @@ public class OptOut implements SpecialCommand {
         String optMessage = userId+",\""+userName+"\""+","+room.getRoomId()+",";
         
         try {
-			if (FileUtils.checkIfLineInFileStartsWith(filename, optMessage)) {
-				FileUtils.removeFromFileStartswith(filename, optMessage);
-				room.replyTo(message.getId(), "You've been removed.");
-			} else {
-				room.replyTo(message.getId(), "You are not opted-in or already opted-out.");
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+            if (FileUtils.checkIfLineInFileStartsWith(filename, optMessage)) {
+                FileUtils.removeFromFileStartswith(filename, optMessage);
+                room.replyTo(message.getId(), "You've been removed.");
+            } else {
+                room.replyTo(message.getId(), "You are not opted-in or already opted-out.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-	@Override
-	public String description() {
-		return "Removed you from the list";
-	}
+    @Override
+    public String description() {
+        return "Removed you from the list";
+    }
 
-	@Override
-	public String name() {
-		return "opt-out";
-	}
+    @Override
+    public String name() {
+        return "opt-out";
+    }
 
 }

--- a/src/main/java/org/sobotics/guttenberg/entities/OptedInUser.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/OptedInUser.java
@@ -34,11 +34,11 @@ public class OptedInUser {
     }
     
     public double getMinScore() {
-    	return this.minScore;
+        return this.minScore;
     }
     
     public void setMinScore(double score) {
-    	this.minScore = score;
+        this.minScore = score;
     }
 
     @Override

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -81,8 +81,8 @@ public class RelatedAnswersFinder {
                 int i = 1;
                 
                 while (i <= 3) {
-                	LOGGER.info("Fetch page "+i);
-                	JsonObject relatedAnswers = ApiUtils.getAnswersToQuestionsByIdString(relatedIds, "stackoverflow", prop.getProperty("apikey", ""));
+                    LOGGER.info("Fetch page "+i);
+                    JsonObject relatedAnswers = ApiUtils.getAnswersToQuestionsByIdString(relatedIds, "stackoverflow", prop.getProperty("apikey", ""));
                     //System.out.println(relatedAnswers);
                     
                     for (JsonElement answer : relatedAnswers.get("items").getAsJsonArray()) {
@@ -93,7 +93,7 @@ public class RelatedAnswersFinder {
                     JsonElement hasMoreElement = relatedAnswers.get("has_more");
                     
                     if (hasMoreElement != null && hasMoreElement.getAsBoolean() == false)
-                    	break;
+                        break;
                     
                     i++;
                 }

--- a/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
+++ b/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
@@ -11,23 +11,23 @@ public class SoBoticsPostPrinter implements PostPrinter {
 
     @Override
     public String print(PlagFinder finder) {
-    	
-    	double score = Math.round(finder.getJaroScore()*100.0)/100.0;
-    	String link = "https://stackoverflow.com/a/"+finder.getJaroAnswer().get("answer_id").getAsString();
-    	String targetLink = "https://stackoverflow.com/a/"+finder.getTargetAnswer().get("answer_id").getAsString();
-    	
-    	int userOne = finder.getJaroAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
-    	int userTwo = finder.getTargetAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
-    	
-    	String post;
-    	
-    	if (userOne != userTwo) {
-    		//plagiarism; different users
-    		post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible plagiarism]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
-    	} else {
-    		//duplicated answer; same user
-    		String user = finder.getTargetAnswer().get("owner").getAsJsonObject().get("display_name").getAsString();
-    		post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible repost]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
+        
+        double score = Math.round(finder.getJaroScore()*100.0)/100.0;
+        String link = "https://stackoverflow.com/a/"+finder.getJaroAnswer().get("answer_id").getAsString();
+        String targetLink = "https://stackoverflow.com/a/"+finder.getTargetAnswer().get("answer_id").getAsString();
+        
+        int userOne = finder.getJaroAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
+        int userTwo = finder.getTargetAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
+        
+        String post;
+        
+        if (userOne != userTwo) {
+            //plagiarism; different users
+            post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible plagiarism]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
+        } else {
+            //duplicated answer; same user
+            String user = finder.getTargetAnswer().get("owner").getAsJsonObject().get("display_name").getAsString();
+            post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible repost]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
       }
         return post;
     }

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -1,0 +1,31 @@
+package org.sobotics.guttenberg.utils;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Utilities for dealing with posts.
+ * @author ArtOfCode
+ */
+public class PostUtils {
+    public static void separateBodyParts(JsonObject answer) {
+        String markdown = answer.get("body_markdown").getAsString();
+        String[] paragraphs = markdown.split("\\n{2,}");
+        
+        String plain = "", code = "", quote = "";
+        for (String paragraph : paragraphs) {
+            if (paragraph.trim().charAt(0) == '>') {
+                quote += paragraph + "\n";
+            }
+            else if (paragraph.startsWith("    ")) {
+                code += paragraph + "\n";
+            }
+            else {
+                plain += paragraph + "\n";
+            }
+        }
+        
+        answer.addProperty("body_plain", plain);
+        answer.addProperty("body_code", code);
+        answer.addProperty("body_quote", quote);
+    }
+}

--- a/src/test/java/org/sobotics/guttenberg/utils/PostUtilsTest.java
+++ b/src/test/java/org/sobotics/guttenberg/utils/PostUtilsTest.java
@@ -1,0 +1,50 @@
+package org.sobotics.guttenberg.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author owen
+ */
+public class PostUtilsTest {
+    
+    public PostUtilsTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testSeparateBodyParts() {
+        JsonParser parser = new JsonParser();
+        JsonObject answer = parser.parse("{\"body_markdown\":\"p1\\n\\np2\\n\\np3\\n\\n>quote\\n\\n    code\"}").getAsJsonObject();
+        PostUtils.separateBodyParts(answer);
+        
+        System.out.println(answer.get("body_plain").toString());
+        
+        assertEquals("p1\np2\np3\n", answer.get("body_plain").getAsString());
+        assertEquals("    code\n", answer.get("body_code").getAsString());
+        assertEquals(">quote\n", answer.get("body_quote").getAsString());
+    }
+    
+}


### PR DESCRIPTION
This would *appear* to work...

Separates posts into plaintext, quotes, and code. As specified in #28, score is calculated as `(plainSimilarity * 0.7) + (quoteSimilarity * 0.5) + codeSimilarity`.

I've added tests for `PostUtils`, which pass locally.

Oh, and another `s/\t/\s{4}/g` to fix formatting.