### PR TITLE
Feature/28 separate post body

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Guttenberg is a bot that searches for plagiarism or duplicated answers on Stack 
 
 ## Implementation
 
-Every 60 seconds, Guttenberg fetches the most recent answers (the "targets") on Stack Overflow. For each of these answers, possibly related posts (for example answers to related questions) are collected. Each related post will be splitted into the full markdown, code-blocks, plaintext paragraphs and blockquotes. These parts are compared with the "target" and the [Jaro-Winkler distance](https://en.wikipedia.org/wiki/Jaro–Winkler_distance) will be calculated. If one of the comparison reaches a certain score (which is defined in `general.properties`), a message like this will be posted in chat:
+Every 60 seconds, Guttenberg fetches the most recent answers (the "targets") on Stack Overflow. For each of these answers, possibly related posts (for example answers to related questions) are collected. Each related post will be split into the full markdown, code-blocks, plaintext paragraphs and blockquotes. These parts are compared with the "target" and the [Jaro-Winkler distance](https://en.wikipedia.org/wiki/Jaro–Winkler_distance) will be calculated. If one of the comparison reaches a certain score (which is defined in `general.properties`), a message like this will be posted in chat:
 
 ![](https://i.imgur.com/HhwCWJr.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>java-string-similarity</artifactId>
             <version>0.21</version>
         </dependency>
+        <dependency>
+        	<groupId>org.jsoup</groupId>
+        	<artifactId>jsoup</artifactId>
+        	<version>1.10.2</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,6 @@
             <artifactId>java-string-similarity</artifactId>
             <version>0.21</version>
         </dependency>
-        <dependency>
-        	<groupId>org.jsoup</groupId>
-        	<artifactId>jsoup</artifactId>
-        	<version>1.10.2</version>
-        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -171,7 +171,7 @@ public class Guttenberg {
 		for (PlagFinder finder : plagFinders) {
 			Post otherAnswer = finder.getMostSimilarAnswer();
 			double score = finder.getJaroScore();
-			if (score > 0.75) {
+			if (score > 0.78) {
 				for (Room room : this.chatRooms) {
 					List<OptedInUser> pingUsersList = UserUtils.pingUserIfApplicable(score, room.getRoomId());
 					if (room.getRoomId() == 111347) {

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -99,9 +99,9 @@ public class Guttenberg {
         }
 		
 		
-		executorService.scheduleAtFixedRate(()->secureExecute(), 15, 59, TimeUnit.SECONDS);
+		executorService.scheduleAtFixedRate(()->secureExecute(), 10, 59, TimeUnit.SECONDS);
 		executorServiceCheck.scheduleAtFixedRate(()->checkLastExecution(), 3, 5, TimeUnit.MINUTES);
-		executorServiceUpdate.scheduleAtFixedRate(()->update(), 0, 30, TimeUnit.MINUTES);
+		executorServiceUpdate.scheduleAtFixedRate(()->update(), 1, 30, TimeUnit.MINUTES);
 		executorServiceLogCleaner.scheduleAtFixedRate(()->cleanLogs(), 0, 4, TimeUnit.HOURS);
 	}
 	

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.finders.NewAnswersFinder;
 import org.sobotics.guttenberg.entities.OptedInUser;
+import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.finders.PlagFinder;
 import org.sobotics.guttenberg.finders.RelatedAnswersFinder;
 import org.sobotics.guttenberg.printers.SoBoticsPostPrinter;
@@ -123,12 +124,12 @@ public class Guttenberg {
 		//NewAnswersFinder answersFinder = new NewAnswersFinder();
 		
 		//Fetch recent answers / The targets
-		JsonArray recentAnswers = NewAnswersFinder.findRecentAnswers();
+		List<Post> recentAnswers = NewAnswersFinder.findRecentAnswers();
 		
 		//Fetch their question_ids
 		List<Integer> ids = new ArrayList<Integer>();
-		for (JsonElement answer : recentAnswers) {
-			Integer id = answer.getAsJsonObject().get("question_id").getAsInt();
+		for (Post answer : recentAnswers) {
+			Integer id = answer.getAnswerID();
 			if (!ids.contains(id))
 				ids.add(id);
 		}
@@ -137,15 +138,15 @@ public class Guttenberg {
 		//Initialize the PlagFinders
 		List<PlagFinder> plagFinders = new ArrayList<PlagFinder>();
 		
-		for (JsonElement answer : recentAnswers) {
-			PlagFinder plagFinder = new PlagFinder(answer.getAsJsonObject());
+		for (Post answer : recentAnswers) {
+			PlagFinder plagFinder = new PlagFinder(answer);
 			plagFinders.add(plagFinder);
 		}
 		
 		//fetch all /questions/ids/answers sort them later
 		
 		RelatedAnswersFinder related = new RelatedAnswersFinder(ids);
-		List<JsonObject> relatedAnswersUnsorted = related.fetchRelatedAnswers();
+		List<Post> relatedAnswersUnsorted = related.fetchRelatedAnswers();
 		
 		if (relatedAnswersUnsorted.isEmpty()) {
 			LOGGER.warn("No related answers could be fetched. Skipping this execution...");
@@ -158,9 +159,9 @@ public class Guttenberg {
 			Integer targetId = finder.getTargetAnswerId();
 			//System.out.println("TargetID: "+targetId);
 			
-			for (JsonObject relatedItem : relatedAnswersUnsorted) {
+			for (Post relatedItem : relatedAnswersUnsorted) {
 				//System.out.println(relatedItem);
-				if (relatedItem.has("answer_id") && relatedItem.get("answer_id").getAsInt() != targetId) {
+				if (relatedItem.getAnswerID() != null && relatedItem.getAnswerID() != targetId) {
 					finder.relatedAnswers.add(relatedItem);
 					//System.out.println("Added answer: "+relatedItem);
 				}
@@ -170,9 +171,9 @@ public class Guttenberg {
 		LOGGER.info("Find the duplicates...");
 		//Let PlagFinders find the best match
 		for (PlagFinder finder : plagFinders) {
-			JsonObject otherAnswer = finder.getMostSimilarAnswer();
+			Post otherAnswer = finder.getMostSimilarAnswer();
 			double score = finder.getJaroScore();
-			if (score > 0.77) {
+			if (score > 0.73) {
 				for (Room room : this.chatRooms) {
 					List<OptedInUser> pingUsersList = UserUtils.pingUserIfApplicable(score, room.getRoomId());
 					if (room.getRoomId() == 111347) {

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -125,11 +125,10 @@ public class Guttenberg {
 		
 		//Fetch recent answers / The targets
 		List<Post> recentAnswers = NewAnswersFinder.findRecentAnswers();
-		
 		//Fetch their question_ids
 		List<Integer> ids = new ArrayList<Integer>();
 		for (Post answer : recentAnswers) {
-			Integer id = answer.getAnswerID();
+			Integer id = answer.getQuestionID();
 			if (!ids.contains(id))
 				ids.add(id);
 		}
@@ -144,7 +143,6 @@ public class Guttenberg {
 		}
 		
 		//fetch all /questions/ids/answers sort them later
-		
 		RelatedAnswersFinder related = new RelatedAnswersFinder(ids);
 		List<Post> relatedAnswersUnsorted = related.fetchRelatedAnswers();
 		
@@ -173,7 +171,7 @@ public class Guttenberg {
 		for (PlagFinder finder : plagFinders) {
 			Post otherAnswer = finder.getMostSimilarAnswer();
 			double score = finder.getJaroScore();
-			if (score > 0.73) {
+			if (score > 0.75) {
 				for (Room room : this.chatRooms) {
 					List<OptedInUser> pingUsersList = UserUtils.pingUserIfApplicable(score, room.getRoomId());
 					if (room.getRoomId() == 111347) {

--- a/src/main/java/org/sobotics/guttenberg/commands/Check.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Check.java
@@ -72,7 +72,7 @@ public class Check implements SpecialCommand {
             finder.collectData();
             finder.getMostSimilarAnswer();
             double score = Math.round(finder.getJaroScore()*100.0)/100.0;
-            String link = finder.getJaroAnswer().get("link").getAsString();
+            String link = "http://stackoverflow.com/a/"+finder.getJaroAnswer().getAnswerID();
 
             if (score > 0) {
                 String reply = "The closest match with a score of **"+score+"** is [this post]("+link+").";

--- a/src/main/java/org/sobotics/guttenberg/entities/Post.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/Post.java
@@ -157,7 +157,10 @@ public class Post {
     	JsonObject parts = PostUtils.separateBodyParts(this);
     	
     	this.codeOnly = parts.get("body_code").getAsString();
-    	this.plaintext = parts.get("body_plain").getAsString();
     	this.quotes = parts.get("body_quote").getAsString();
+    	
+    	String plain = parts.get("body_plain").getAsString();
+    	plain.replaceFirst("\\d*\\s*up\\s*vote\\s*\\d*\\s*down\\s*vote", "");
+    	this.plaintext = plain;
     }
 }

--- a/src/main/java/org/sobotics/guttenberg/entities/Post.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/Post.java
@@ -1,0 +1,143 @@
+package org.sobotics.guttenberg.entities;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+/**
+ * Created by bhargav.h on 11-Sep-16.
+ */
+public class Post {
+    private String title;
+    private Instant answerCreationDate;
+    private Integer answerID;
+    private Integer questionID;
+    private String body;
+    private String bodyMarkdown;
+    private SOUser answerer;
+    private double score = 0;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instant getAnswerCreationDate() {
+        return answerCreationDate;
+    }
+
+    public void setAnswerCreationDate(Instant answerCreationDate) {
+        this.answerCreationDate = answerCreationDate;
+    }
+
+    public Integer getAnswerID() {
+        return answerID;
+    }
+
+    public void setAnswerID(Integer answerID) {
+        this.answerID = answerID;
+    }
+
+    public Integer getQuestionID() {
+        return questionID;
+    }
+
+    public void setQuestionID(Integer questionID) {
+        this.questionID = questionID;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getBodyMarkdown() {
+        return bodyMarkdown;
+    }
+
+    public void setBodyMarkdown(String bodyMarkdown) {
+        this.bodyMarkdown = bodyMarkdown;
+    }
+
+    public SOUser getAnswerer() {
+        return answerer;
+    }
+
+    public void setAnswerer(SOUser answerer) {
+        this.answerer = answerer;
+    }
+
+    @Override
+    public String toString() {
+
+        JsonObject json = getJson();
+        return json.toString();
+    }
+
+    @NotNull
+    private JsonObject getJson() {
+        JsonObject json = new JsonObject();
+
+        json.addProperty("title" , title );
+        json.addProperty("answerCreationDate" , answerCreationDate.toString());
+        json.addProperty("answerID" , answerID);
+        json.addProperty("body" , body );
+        json.addProperty("bodyMarkdown" , bodyMarkdown);
+        json.add("answerer" , answerer.getJson());
+        return json;
+
+    }
+    
+    public String getCodeOnly() {
+    	String codeOnly = "";
+    	
+    	Document doc = Jsoup.parse(body);
+    	Elements pres = doc.getElementsByTag("pre");
+    	
+    	Elements codes = new Elements();
+    	
+    	for (Element pre: pres) {
+    		Elements codeInPre = pre.getElementsByTag("code");
+    		for (Element code : codeInPre) {
+    			codes.add(code);
+    		}
+    	}
+    	
+    	for (Element code : codes) {
+    		codeOnly += code.html();
+    	}
+    	
+		return codeOnly;
+    }
+    
+    public String getPlaintext() {
+    	Document doc = Jsoup.parse(body);
+    	Elements pres = doc.getElementsByClass("prettyprint");
+    	for (Element pre: pres) {
+    		pre.remove();
+    	}
+    	
+    	
+    	return doc.text();
+    }
+    
+    public void setScore(double newScore) {
+    	this.score = newScore;
+    }
+    
+    public double getScore() {
+    	return this.score;
+    }
+}

--- a/src/main/java/org/sobotics/guttenberg/entities/Post.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/Post.java
@@ -6,6 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.sobotics.guttenberg.utils.PostUtils;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -21,6 +22,11 @@ public class Post {
     private String body;
     private String bodyMarkdown;
     private SOUser answerer;
+    
+    private String codeOnly;
+    private String plaintext;
+    private String quotes;
+    
     private double score = 0;
 
     public String getTitle() {
@@ -101,7 +107,8 @@ public class Post {
     }
     
     public String getCodeOnly() {
-    	String codeOnly = "";
+    	return this.codeOnly != null ? this.codeOnly : "";
+    	/*String codeOnly = "";
     	
     	Document doc = Jsoup.parse(body);
     	Elements pres = doc.getElementsByTag("pre");
@@ -119,18 +126,23 @@ public class Post {
     		codeOnly += code.html();
     	}
     	
-		return codeOnly;
+		return codeOnly;*/
     }
     
     public String getPlaintext() {
-    	Document doc = Jsoup.parse(body);
+    	return this.plaintext != null ? this.plaintext : "";
+    	/*Document doc = Jsoup.parse(body);
     	Elements pres = doc.getElementsByClass("prettyprint");
     	for (Element pre: pres) {
     		pre.remove();
     	}
     	
     	
-    	return doc.text();
+    	return doc.text();*/
+    }
+    
+    public String getQuotes() {
+    	return this.quotes != null ? this.quotes : "";
     }
     
     public void setScore(double newScore) {
@@ -139,5 +151,13 @@ public class Post {
     
     public double getScore() {
     	return this.score;
+    }
+    
+    public void parsePost() {
+    	JsonObject parts = PostUtils.separateBodyParts(this);
+    	
+    	this.codeOnly = parts.get("body_code").getAsString();
+    	this.plaintext = parts.get("body_plain").getAsString();
+    	this.quotes = parts.get("body_quote").getAsString();
     }
 }

--- a/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
@@ -3,16 +3,21 @@ package org.sobotics.guttenberg.finders;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.PostUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 /**
  * Fetches the most recent answers
@@ -21,7 +26,7 @@ public class NewAnswersFinder {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(NewAnswersFinder.class);
     
-    public static JsonArray findRecentAnswers() {
+    public static List<Post> findRecentAnswers() {
         //long unixTime = (long)System.currentTimeMillis()/1000;
         Instant time = Instant.now().minusSeconds(59+1);
         
@@ -37,7 +42,7 @@ public class NewAnswersFinder {
         }
         catch (IOException e){
             LOGGER.error("Could not load login.properties", e);
-            return new JsonArray();
+            return new ArrayList<Post>();
         }
         
         try {
@@ -47,13 +52,19 @@ public class NewAnswersFinder {
             JsonArray items = apiResult.get("items").getAsJsonArray();
             //System.out.println(items);
             LOGGER.info("findRecentAnswers() done with "+items.size()+" items");
+            List<Post> posts = new ArrayList<Post>();
             
-            return items;
+            for (JsonElement item : items) {
+            	Post post = PostUtils.getPost(item.getAsJsonObject());
+            	posts.add(post);
+            }
+            
+            return posts;
             
             
         } catch (IOException e) {
             LOGGER.error("Could not load recent answers", e);
-            return new JsonArray();
+            return new ArrayList<Post>();
         }
     }
     

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -131,6 +131,7 @@ public class PlagFinder {
         String targetBodyMarkdown = this.targetAnswer.getBodyMarkdown();
         String targetCodeOnly = this.targetAnswer.getCodeOnly();
         String targetPlaintext = this.targetAnswer.getPlaintext();
+        String targetQuotes = this.targetAnswer.getQuotes();
         Instant targetDate = this.targetAnswer.getAnswerCreationDate();
         double highscore = 0;
         Post closestMatch = this.targetAnswer;
@@ -144,11 +145,13 @@ public class PlagFinder {
         double quantifierBodyMarkdown = 1;
         double quantifierCodeOnly = 1;
         double quantifierPlaintext = 1;
+        double quantifierQuotes = 1;
         
         try {
         	quantifierBodyMarkdown = new Double(quantifiers.getProperty("quantifierBodyMarkdown", "1"));
         	quantifierCodeOnly = new Double(quantifiers.getProperty("quantifierCodeOnly", "1"));
         	quantifierPlaintext = new Double(quantifiers.getProperty("quantifierPlaintext", "1"));
+        	quantifierQuotes = new Double(quantifiers.getProperty("quantifierQuotes", "1"));
         } catch (Throwable e) {
         	LOGGER.warn("Using hardcoded value", e);
         }
@@ -159,15 +162,18 @@ public class PlagFinder {
             String answerBodyMarkdown = answer.getBodyMarkdown();
             String answerCodeOnly = answer.getCodeOnly();
             String answerPlaintext = answer.getPlaintext();
+            String answerQuotes = answer.getQuotes();
             Instant answerDate = answer.getAnswerCreationDate();
             //double jaroWinklerScore = jw.similarity(targetText, answerBody);
             
             double jwBodyMarkdown = jw.similarity(targetBodyMarkdown, answerBodyMarkdown)
             		* quantifierBodyMarkdown;
-            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly)
-            		* quantifierCodeOnly;
-            double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext)
-            		* quantifierPlaintext;
+            double jwCodeOnly = answerCodeOnly != null ? ( jw.similarity(targetCodeOnly, answerCodeOnly)
+            		* quantifierCodeOnly) : 0;
+            double jwPlaintext = answerPlaintext != null ? ( jw.similarity(answerPlaintext, targetPlaintext)
+            		* quantifierPlaintext) : 0;
+            double jwQuotes = answerQuotes != null ? ( jw.similarity(answerQuotes, targetQuotes)
+            		* quantifierQuotes) : 0;
             
             //LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
             
@@ -177,10 +183,12 @@ public class PlagFinder {
             */
             double usedScores = (jwBodyMarkdown > 0 ? quantifierBodyMarkdown : 0)
             		+ (jwCodeOnly > 0 ? quantifierCodeOnly : 0)
-            		+ (jwPlaintext > 0 ? quantifierPlaintext : 0);
+            		+ (jwPlaintext > 0 ? quantifierPlaintext : 0)
+            		+ (jwQuotes > 0 ? quantifierQuotes : 0);
             double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 0) 
             		+ (jwCodeOnly > 0 ? jwCodeOnly : 0)
-            		+ (jwPlaintext > 0 ? jwPlaintext : 0)) / usedScores;
+            		+ (jwPlaintext > 0 ? jwPlaintext : 0)
+            		+ (jwQuotes > 0 ? jwQuotes : 0)) / usedScores;
             
             
             //LOGGER.info("Score: "+jaroWinklerScore+"\nUsed scores: "+usedScores+"\nbodyMarkdown: "+jwBodyMarkdown+"\ncodeOnly: "+jwCodeOnly+"\nplaintext: "+jwPlaintext);

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -144,9 +144,9 @@ public class PlagFinder {
             Instant answerDate = answer.getAnswerCreationDate();
             //double jaroWinklerScore = jw.similarity(targetText, answerBody);
             
-            double jwBodyMarkdown = jw.similarity(targetBodyMarkdown, answerBodyMarkdown);
-            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly);
-            double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext);
+            double jwBodyMarkdown = jw.similarity(targetBodyMarkdown, answerBodyMarkdown) * 1;
+            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly) * 5;
+            double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext) * 1;
             
             //LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
             
@@ -155,11 +155,14 @@ public class PlagFinder {
             		* (jwPlaintext > 0 ? jwPlaintext : 1)*0.95;
             */
             double usedScores = (jwBodyMarkdown > 0 ? 1 : 0)
-            		+ (jwCodeOnly > 0 ? 1 : 0)
+            		+ (jwCodeOnly > 0 ? 4 : 0)
             		+ (jwPlaintext > 0 ? 1 : 0);
             double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 0)*0.9 
             		+ (jwCodeOnly > 0 ? jwCodeOnly : 0)*1.0 
             		+ (jwPlaintext > 0 ? jwPlaintext : 0)*0.95) / usedScores;
+            
+            
+            //LOGGER.info("Score: "+jaroWinklerScore+"\nUsed scores: "+usedScores+"\nbodyMarkdown: "+jwBodyMarkdown+"\ncodeOnly: "+jwCodeOnly+"\nplaintext: "+jwPlaintext);
             
             if (jwBodyMarkdown > 0.9)
             	jaroWinklerScore = jwBodyMarkdown;

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -154,9 +154,9 @@ public class PlagFinder {
             		* (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
             		* (jwPlaintext > 0 ? jwPlaintext : 1)*0.95;
             */
-            double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 1)*0.7 
+            double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 1)*0.6 
             		+ (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
-            		+ (jwPlaintext > 0 ? jwPlaintext : 1)*0.8) / 3;
+            		+ (jwPlaintext > 0 ? jwPlaintext : 1)*0.75) / 3;
             
             if (jwBodyMarkdown > 0.9)
             	jaroWinklerScore = jwBodyMarkdown;

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -145,7 +145,7 @@ public class PlagFinder {
             //double jaroWinklerScore = jw.similarity(targetText, answerBody);
             
             double jwBodyMarkdown = jw.similarity(targetBodyMarkdown, answerBodyMarkdown) * 1;
-            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly) * 5;
+            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly) * 3;
             double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext) * 1;
             
             //LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
@@ -155,7 +155,7 @@ public class PlagFinder {
             		* (jwPlaintext > 0 ? jwPlaintext : 1)*0.95;
             */
             double usedScores = (jwBodyMarkdown > 0 ? 1 : 0)
-            		+ (jwCodeOnly > 0 ? 4 : 0)
+            		+ (jwCodeOnly > 0 ? 3 : 0)
             		+ (jwPlaintext > 0 ? 1 : 0);
             double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 0)*0.9 
             		+ (jwCodeOnly > 0 ? jwCodeOnly : 0)*1.0 

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -2,14 +2,17 @@ package org.sobotics.guttenberg.finders;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.PostUtils;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -26,39 +29,44 @@ public class PlagFinder {
     /**
      * The answer to check
      * */
-    private JsonObject targetAnswer;
+    private Post targetAnswer;
     
     /**
      * A list of answers that are somehow related to targetAnswer.
      * */
-    public List<JsonObject> relatedAnswers;
+    public List<Post> relatedAnswers;
     
     private double jaroScore = 0;
     
-    private JsonObject jaroAnswer;
+    private Post jaroAnswer;
     
     /**
      * Initializes the PlagFinder with an answer that should be checked for plagiarism
      * */
     public PlagFinder(JsonObject jsonObject) {
-        this.targetAnswer = jsonObject;
-        this.relatedAnswers = new ArrayList<JsonObject>();
+        this.targetAnswer = PostUtils.getPost(jsonObject);
+        this.relatedAnswers = new ArrayList<Post>();
     }
     
-    public PlagFinder(JsonObject target, List<JsonObject> related) {
+    public PlagFinder(Post post) {
+    	this.targetAnswer = post;
+    	this.relatedAnswers = new ArrayList<Post>();
+    }
+    
+    public PlagFinder(Post target, List<Post> related) {
         this.targetAnswer = target;
         this.relatedAnswers = related;
     }
     
     public void collectData() {
-        this.relatedAnswers = new ArrayList<JsonObject>();
+        this.relatedAnswers = new ArrayList<Post>();
         this.fetchRelatedAnswers();
         LOGGER.info("RelatedAnswers: "+this.relatedAnswers.size());
     }
     
     private void fetchRelatedAnswers() {
-        int targetId = this.targetAnswer.get("question_id").getAsInt();
-        int targetAnswerId = this.targetAnswer.get("answer_id").getAsInt();
+        int targetId = this.targetAnswer.getQuestionID();
+        int targetAnswerId = this.targetAnswer.getAnswerID();
         LOGGER.info("Target: "+targetId);
         Properties prop = new Properties();
 
@@ -99,11 +107,12 @@ public class PlagFinder {
                 //System.out.println(relatedAnswers);
                 for (JsonElement answer : relatedAnswers.get("items").getAsJsonArray()) {
                     JsonObject answerObject = answer.getAsJsonObject();
+                    Post answerPost = PostUtils.getPost(answerObject);
                     
-                    int answerId = answerObject.get("answer_id").getAsInt();
+                    int answerId = answerPost.getAnswerID();
                     
                     if (answerId != targetAnswerId)
-                        this.relatedAnswers.add(answerObject);
+                        this.relatedAnswers.add(answerPost);
                 }
                 
                 
@@ -118,23 +127,34 @@ public class PlagFinder {
     }
     
     
-    public JsonObject getMostSimilarAnswer() {
-        String targetText = this.targetAnswer.get("body_markdown").getAsString();
-        int targetDate = this.targetAnswer.get("creation_date").getAsInt();
+    public Post getMostSimilarAnswer() {
+        String targetBodyMarkdown = this.targetAnswer.getBodyMarkdown();
+        String targetCodeOnly = this.targetAnswer.getCodeOnly();
+        String targetPlaintext = this.targetAnswer.getPlaintext();
+        Instant targetDate = this.targetAnswer.getAnswerCreationDate();
         double highscore = 0;
-        JsonObject closestMatch = this.targetAnswer;
-        closestMatch.addProperty("jaro_winkler", 0);
+        Post closestMatch = this.targetAnswer;
                 
         JaroWinkler jw = new JaroWinkler();
                 
-        for (JsonObject answer : this.relatedAnswers) {
-            String answerBody = answer.get("body_markdown").getAsString();
-            int answerDate = answer.get("last_activity_date").getAsInt();
-            double jaroWinklerScore = jw.similarity(targetText, answerBody);
-            if (highscore < jaroWinklerScore && targetDate > answerDate) {
+        for (Post answer : this.relatedAnswers) {
+            String answerBodyMarkdown = answer.getBodyMarkdown();
+            String answerCodeOnly = answer.getCodeOnly();
+            String answerPlaintext = answer.getPlaintext();
+            Instant answerDate = answer.getAnswerCreationDate();
+            //double jaroWinklerScore = jw.similarity(targetText, answerBody);
+            
+            double jwBodyMarkdown = jw.similarity(targetBodyMarkdown, answerBodyMarkdown);
+            double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly);
+            double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext);
+            
+            LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
+            
+            double jaroWinklerScore = jwBodyMarkdown*0.6 + jwCodeOnly*1.0 + jwPlaintext*0.7;
+            if (highscore < jaroWinklerScore && targetDate.isAfter(answerDate)) {
                 //new highscore
                 highscore = jaroWinklerScore;
-                answer.addProperty("jaro_winkler", jaroWinklerScore);
+                answer.setScore(highscore);
                 closestMatch = answer;
             }
         }
@@ -147,19 +167,19 @@ public class PlagFinder {
     }
     
     
-    public JsonObject getTargetAnswer() {
+    public Post getTargetAnswer() {
         return this.targetAnswer;
     }
     
     public Integer getTargetAnswerId() {
-        return this.targetAnswer.get("answer_id").getAsInt();
+        return this.targetAnswer.getAnswerID();
     }
     
     public double getJaroScore() {
         return this.jaroScore;
     }
     
-    public JsonObject getJaroAnswer() {
+    public Post getJaroAnswer() {
         return this.jaroAnswer;
         //return this.jaroScore > 0.7 ? this.jaroAnswer : null;
     }

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -154,9 +154,12 @@ public class PlagFinder {
             		* (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
             		* (jwPlaintext > 0 ? jwPlaintext : 1)*0.95;
             */
-            double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 1)*0.6 
-            		+ (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
-            		+ (jwPlaintext > 0 ? jwPlaintext : 1)*0.75) / 3;
+            double usedScores = (jwBodyMarkdown > 0 ? 1 : 0)
+            		+ (jwCodeOnly > 0 ? 1 : 0)
+            		+ (jwPlaintext > 0 ? 1 : 0);
+            double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 0)*0.9 
+            		+ (jwCodeOnly > 0 ? jwCodeOnly : 0)*1.0 
+            		+ (jwPlaintext > 0 ? jwPlaintext : 0)*0.95) / usedScores;
             
             if (jwBodyMarkdown > 0.9)
             	jaroWinklerScore = jwBodyMarkdown;

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -148,9 +148,19 @@ public class PlagFinder {
             double jwCodeOnly = jw.similarity(targetCodeOnly, answerCodeOnly);
             double jwPlaintext = jw.similarity(answerPlaintext, targetPlaintext);
             
-            LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
+            //LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
             
-            double jaroWinklerScore = jwBodyMarkdown*0.6 + jwCodeOnly*1.0 + jwPlaintext*0.7;
+            /*double jaroWinklerScore = (jwBodyMarkdown > 0 ? jwBodyMarkdown : 1)*0.92 
+            		* (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
+            		* (jwPlaintext > 0 ? jwPlaintext : 1)*0.95;
+            */
+            double jaroWinklerScore = ((jwBodyMarkdown > 0 ? jwBodyMarkdown : 1)*0.7 
+            		+ (jwCodeOnly > 0 ? jwCodeOnly : 1)*1.0 
+            		+ (jwPlaintext > 0 ? jwPlaintext : 1)*0.8) / 3;
+            
+            if (jwBodyMarkdown > 0.9)
+            	jaroWinklerScore = jwBodyMarkdown;
+            
             if (highscore < jaroWinklerScore && targetDate.isAfter(answerDate)) {
                 //new highscore
                 highscore = jaroWinklerScore;

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -8,8 +8,10 @@ import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.PostUtils;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -31,7 +33,7 @@ public class RelatedAnswersFinder {
     }
     
     
-    public List<JsonObject> fetchRelatedAnswers() {
+    public List<Post> fetchRelatedAnswers() {
         //The question_ids of all the new answers
         String idString = "";
         int n = 0;
@@ -97,9 +99,16 @@ public class RelatedAnswersFinder {
                     
                     i++;
                 }
+                
+                List<Post> relatedPosts = new ArrayList<Post>();
+                for (JsonElement item : relatedFinal) {
+                	Post post = PostUtils.getPost(item.getAsJsonObject());
+                	relatedPosts.add(post);
+                }
                                 
                 LOGGER.info("Collected "+relatedFinal.size()+" answers");
-                return relatedFinal;
+                
+                return relatedPosts;
             } else {
                 LOGGER.warn("No ids found!");
             }
@@ -107,12 +116,12 @@ public class RelatedAnswersFinder {
             
         } catch (IOException e) {
             LOGGER.error("Error in RelatedAnswersFinder", e);
-            return new ArrayList<JsonObject>();
+            return new ArrayList<Post>();
         }
         
         
         
-        return new ArrayList<JsonObject>();
+        return new ArrayList<Post>();
     }
     
     

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -82,7 +82,7 @@ public class RelatedAnswersFinder {
                 boolean hasMore = true;
                 int i = 1;
                 
-                while (i <= 2) {
+                while (i <= 3) {
                 	LOGGER.info("Fetch page "+i);
                 	JsonObject relatedAnswers = ApiUtils.getAnswersToQuestionsByIdString(relatedIds, "stackoverflow", prop.getProperty("apikey", ""));
                     //System.out.println(relatedAnswers);

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -82,7 +82,7 @@ public class RelatedAnswersFinder {
                 boolean hasMore = true;
                 int i = 1;
                 
-                while (i <= 3) {
+                while (i <= 2) {
                 	LOGGER.info("Fetch page "+i);
                 	JsonObject relatedAnswers = ApiUtils.getAnswersToQuestionsByIdString(relatedIds, "stackoverflow", prop.getProperty("apikey", ""));
                     //System.out.println(relatedAnswers);

--- a/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
+++ b/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
@@ -13,11 +13,11 @@ public class SoBoticsPostPrinter implements PostPrinter {
     public String print(PlagFinder finder) {
     	
     	double score = Math.round(finder.getJaroScore()*100.0)/100.0;
-    	String link = "https://stackoverflow.com/a/"+finder.getJaroAnswer().get("answer_id").getAsString();
-    	String targetLink = "https://stackoverflow.com/a/"+finder.getTargetAnswer().get("answer_id").getAsString();
+    	String link = "https://stackoverflow.com/a/"+finder.getJaroAnswer().getAnswerID();
+    	String targetLink = "https://stackoverflow.com/a/"+finder.getTargetAnswer().getAnswerID();
     	
-    	int userOne = finder.getJaroAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
-    	int userTwo = finder.getTargetAnswer().get("owner").getAsJsonObject().get("user_id").getAsInt();
+    	int userOne = finder.getJaroAnswer().getAnswerer().getUserId();
+    	int userTwo = finder.getTargetAnswer().getAnswerer().getUserId();
     	
     	String post;
     	
@@ -26,7 +26,7 @@ public class SoBoticsPostPrinter implements PostPrinter {
     		post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible plagiarism]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
     	} else {
     		//duplicated answer; same user
-    		String user = finder.getTargetAnswer().get("owner").getAsJsonObject().get("display_name").getAsString();
+    		String user = finder.getTargetAnswer().getAnswerer().getUsername();
     		post = "[ [Guttenberg](http://stackapps.com/q/7197/43403) ] [Possible repost]("+targetLink+") with a score of **"+ score +"**. [Original post]("+link+")";
       }
         return post;

--- a/src/main/java/org/sobotics/guttenberg/utils/ApiUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/ApiUtils.java
@@ -37,7 +37,7 @@ public class ApiUtils {
     
     public static JsonObject getAnswersToQuestionsByIdString(String questionIds, String site, String apiKey) throws IOException{
         String questionIdUrl = "https://api.stackexchange.com/2.2/questions/"+questionIds+"/answers";
-        return JsonUtils.get(questionIdUrl,"site",site,"key",apiKey,"filter","!t)IWLWWlT0rQE-hWF8Ung(Zwi(MVd)*","pagesize","100");
+        return JsonUtils.get(questionIdUrl,"site",site,"key",apiKey,"filter","!0X*TZmuJB2WzlS4ay0*c9y3Wy","pagesize","100");
     }
     
     public static JsonObject getQuestionDetailsByIds(List<Integer> questionIdList, String site, String apiKey) throws IOException {

--- a/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
@@ -1,6 +1,7 @@
 package org.sobotics.guttenberg.utils;
 
 public class FilePathUtils {
+	public static String generalPropertiesFile = "./properties/general.properties";
     public static String loginPropertiesFile = "./properties/login.properties";
     public static String optedUsersFile = "./data/OptedInUsersList.txt";
 }

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -1,0 +1,43 @@
+package org.sobotics.guttenberg.utils;
+
+import java.time.Instant;
+import java.util.stream.StreamSupport;
+
+import org.sobotics.guttenberg.entities.Post;
+import org.sobotics.guttenberg.entities.SOUser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class PostUtils {
+	public static Post getPost(JsonObject answer){
+
+        Post np = new Post();
+
+        JsonObject answererJSON = answer.get("owner").getAsJsonObject();
+
+        np.setAnswerCreationDate(Instant.ofEpochSecond(answer.get("creation_date").getAsInt()));
+        np.setAnswerID(answer.get("answer_id").getAsInt());
+        np.setQuestionID(answer.get("question_id").getAsInt());
+        np.setBody(answer.get("body").getAsString());
+        np.setBodyMarkdown(JsonUtils.escapeHtmlEncoding(answer.get("body_markdown").getAsString()));
+
+        SOUser answerer = new SOUser();
+
+        try{
+            answerer.setReputation(answererJSON.get("reputation").getAsLong());
+            answerer.setUsername(JsonUtils.escapeHtmlEncoding(answererJSON.get("display_name").getAsString()));
+            answerer.setUserType(answererJSON.get("user_type").getAsString());
+            answerer.setUserId(answererJSON.get("user_id").getAsInt());
+        }
+        catch (Exception e){
+            System.out.println("ANSWERER"+answererJSON);
+            e.printStackTrace();
+        }
+
+        np.setAnswerer(answerer);
+
+        return np;
+
+    }
+}

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -40,4 +40,34 @@ public class PostUtils {
         return np;
 
     }
+	
+	/**
+	 * Splits a post into code, plaintext and quotes
+	 * 
+	 * @author ArtOfCode
+	 * */
+	public static JsonObject separateBodyParts(Post post) {
+		JsonObject result = new JsonObject();
+        String markdown = post.getBodyMarkdown();
+        String[] paragraphs = markdown.split("\\n{2,}");
+        
+        String plain = "", code = "", quote = "";
+        for (String paragraph : paragraphs) {
+            if (paragraph.trim().charAt(0) == '>') {
+                quote += paragraph + "\n";
+            }
+            else if (paragraph.startsWith("    ")) {
+                code += paragraph + "\n";
+            }
+            else {
+                plain += paragraph + "\n";
+            }
+        }
+        
+        result.addProperty("body_plain", plain);
+        result.addProperty("body_code", code);
+        result.addProperty("body_quote", quote);
+        
+        return result;
+    }
 }


### PR DESCRIPTION
Completely changed the structure of how to handle posts. To do this, I've added Natty's `Post` and `SOUser` classes and some other code.

The code to separate the body into plaintext, code and blockquotes, I've used the code from #51 

Additionally, the minimum score to report posts is not hardcoded anymore. It defined in `general.properties`.

---

Closes #28 
Closes #51 