### PR TITLE
- exit() already in the updater without waiting

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/clients/Updater.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Updater.java
@@ -93,6 +93,7 @@ public class Updater {
             LOGGER.info("New version available: "+this.newVersion.get());
             try {
                 Runtime.getRuntime().exec("nohup java -cp guttenberg-"+this.newVersion.get()+".jar org.sobotics.guttenberg.clients.Client");
+                System.exit(0);
                 return true;
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
I observed that updating can result in running multiple instances. It seems like the old process wasn't closed correctly. I guess this can be solved by doing `System.exit(0);` already in the updater without waiting