### PR TITLE
Feature/61 filter so snippets

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/entities/Post.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/Post.java
@@ -161,6 +161,7 @@ public class Post {
     	
     	String plain = parts.get("body_plain").getAsString();
     	plain.replaceFirst("\\d*\\s*up\\s*vote\\s*\\d*\\s*down\\s*vote", "");
+    	plain.replaceAll("<!--.*-->", "");
     	this.plaintext = plain;
     }
 }


### PR DESCRIPTION
Snippets (and syntax-highlighting) are defined like this:

```
<!-- begin snippet: js hide: false console: true babel: false -->
```

By removing those stuff, we could decrease the number of fps containing runnable code-snippets.

---

Closes #61 