### PR TITLE
#59: - fixed exception on launch, which resulted in launch date of null

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -61,6 +61,7 @@ public class Guttenberg {
         this.executorService = Executors.newSingleThreadScheduledExecutor();
         this.executorServiceCheck = Executors.newSingleThreadScheduledExecutor();
         this.executorServiceUpdate = Executors.newSingleThreadScheduledExecutor();
+        this.executorServiceLogCleaner = Executors.newSingleThreadScheduledExecutor();
         chatRooms = new ArrayList<>();
         
         //this.setLogfile();


### PR DESCRIPTION
I didn't initialize the new `executorServiceLogCleaner `, which resulted in an uncaught `NullPointerException` while launching. That was the reason why the launch date was not written correctly. (and obviously, the logs haven't been cleaned)

---

Fixes #59 