### PR TITLE
Feature/103 store feedback

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -43,7 +43,7 @@ public class SoBoticsCommandsList {
 				new CheckUser(message),
 				new Check(message), 
 				new ClearHelp(message),
-				new Feedback(message),
+				new Feedback(message, event),
 				//new OptIn(message),
 				//new OptOut(message), 
 				new Quota(message), 

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -43,7 +43,7 @@ public class SoBoticsCommandsList {
 				new CheckUser(message),
 				new Check(message), 
 				new ClearHelp(message),
-				new Feedback(message, event),
+				new Feedback(message, event, room),
 				//new OptIn(message),
 				//new OptOut(message), 
 				new Quota(message), 

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -1,6 +1,8 @@
 package org.sobotics.guttenberg.commandlists;
 
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,6 +15,7 @@ import org.sobotics.redunda.PingService;
 import org.sobotics.guttenberg.commands.*;
 import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 
 import fr.tunaki.stackoverflow.chat.Message;
 import fr.tunaki.stackoverflow.chat.Room;
@@ -39,9 +42,10 @@ public class SoBoticsCommandsList {
 				new CheckInternet(message),
 				new CheckUser(message),
 				new Check(message), 
-				new ClearHelp(message), 
-				new OptIn(message),
-				new OptOut(message), 
+				new ClearHelp(message),
+				new Feedback(message),
+				//new OptIn(message),
+				//new OptOut(message), 
 				new Quota(message), 
 				new Say(message), 
 				new Status(message), 
@@ -92,6 +96,25 @@ public class SoBoticsCommandsList {
 			room.send("[🚃](http://bit.ly/2nRi9kX)");
 			return;
 		}
+		
+		
+		//we hate fun
+		try {
+			String lowercaseMsg = message.getPlainContent().toLowerCase();
+			if (lowercaseMsg.contains("cat")) {
+				File file = new File("./data/catgifs.txt");
+				String img = FileUtils.randomLine(file);
+				if (img != null && !img.isEmpty())
+					room.send(img);
+			}
+			if (lowercaseMsg.contains("trump")) {
+				File file = new File("./data/drumpf.txt");
+				String img = FileUtils.randomLine(file);
+				if (img != null && !img.isEmpty())
+					room.send(img);
+			}
+		} catch (Throwable ignore) {}
+		
 
 		// return immediately, if @gut is part of the message!
 		String username = "";

--- a/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
@@ -10,6 +10,7 @@ import org.sobotics.guttenberg.utils.PostUtils;
 
 import fr.tunaki.stackoverflow.chat.Message;
 import fr.tunaki.stackoverflow.chat.Room;
+import fr.tunaki.stackoverflow.chat.event.PingMessageEvent;
 
 /**
  * Created by bhargav.h on 29-Nov-16.
@@ -19,9 +20,11 @@ public class Feedback implements SpecialCommand {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Feedback.class);
 	
     private Message message;
+    private PingMessageEvent event;
 
-    public Feedback(Message message) {
+    public Feedback(Message message, PingMessageEvent ping) {
         this.message = message;
+        this.event = ping;
     }
 
     @Override
@@ -60,14 +63,14 @@ public class Feedback implements SpecialCommand {
         
         try {
 			if (type.equalsIgnoreCase("tp") || type.equalsIgnoreCase("k")) {
-				if (isSELink) {
-					PostUtils.storeFeedback(null, reportId, "tp");
+				if (!isSELink) {
+					PostUtils.storeFeedback(this.event, reportId, "tp");
 				}
 			}
 			
 			if (type.equalsIgnoreCase("fp") || type.equalsIgnoreCase("f")) {
-				if (isSELink) {
-					PostUtils.storeFeedback(null, reportId, "fp");
+				if (!isSELink) {
+					PostUtils.storeFeedback(this.event, reportId, "fp");
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
@@ -21,10 +21,12 @@ public class Feedback implements SpecialCommand {
 	
     private Message message;
     private PingMessageEvent event;
+    private Room room;
 
-    public Feedback(Message message, PingMessageEvent ping) {
+    public Feedback(Message message, PingMessageEvent ping, Room room) {
         this.message = message;
         this.event = ping;
+        this.room = room;
     }
 
     @Override
@@ -64,13 +66,13 @@ public class Feedback implements SpecialCommand {
         try {
 			if (type.equalsIgnoreCase("tp") || type.equalsIgnoreCase("k")) {
 				if (!isSELink) {
-					PostUtils.storeFeedback(this.event, reportId, "tp");
+					PostUtils.storeFeedback(this.room, this.event, reportId, "tp");
 				}
 			}
 			
 			if (type.equalsIgnoreCase("fp") || type.equalsIgnoreCase("f")) {
 				if (!isSELink) {
-					PostUtils.storeFeedback(this.event, reportId, "fp");
+					PostUtils.storeFeedback(this.room, this.event, reportId, "fp");
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
@@ -1,0 +1,92 @@
+package org.sobotics.guttenberg.commands;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sobotics.guttenberg.services.RunnerService;
+import org.sobotics.guttenberg.utils.CommandUtils;
+import org.sobotics.guttenberg.utils.PostUtils;
+
+import fr.tunaki.stackoverflow.chat.Message;
+import fr.tunaki.stackoverflow.chat.Room;
+
+/**
+ * Created by bhargav.h on 29-Nov-16.
+ */
+public class Feedback implements SpecialCommand {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Feedback.class);
+	
+    private Message message;
+
+    public Feedback(Message message) {
+        this.message = message;
+    }
+
+    @Override
+    public boolean validate() {
+        return CommandUtils.checkForCommand(message.getPlainContent(),"feedback");
+    }
+
+    @Override
+    public void execute(Room room, RunnerService instance) {
+    	boolean isSELink = false;
+    	int reportId = -1;
+        String args[] = CommandUtils.extractData(message.getPlainContent()).trim().split(" ");
+
+        if(args.length!=2){
+            room.send("Error in arguments passed");
+            return;
+        }
+
+        String word = args[0];
+        String type = args[1];
+
+        if(word.contains("/"))
+        {
+            word = CommandUtils.getAnswerId(word);
+            isSELink = true;
+        }
+        
+        try {
+        	reportId = Integer.parseInt(word);
+        } catch (Exception e) {
+        	LOGGER.info("Invalid report-ID", e);
+        }
+        
+        if (reportId == -1)
+        	return;
+        
+        try {
+			if (type.equalsIgnoreCase("tp") || type.equalsIgnoreCase("k")) {
+				if (isSELink) {
+					PostUtils.storeFeedback(null, reportId, "tp");
+				}
+			}
+			
+			if (type.equalsIgnoreCase("fp") || type.equalsIgnoreCase("f")) {
+				if (isSELink) {
+					PostUtils.storeFeedback(null, reportId, "fp");
+				}
+			}
+		} catch (IOException e) {
+			LOGGER.error("Could not store feedback!", e);
+		}
+    }
+
+    @Override
+    public String description() {
+        return "Provides feedback on a given report";
+    }
+
+    @Override
+    public String name() {
+        return "feedback";
+    }
+
+	@Override
+	public boolean availableInStandby() {
+		return false;
+	}
+}

--- a/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
@@ -1,5 +1,7 @@
 package org.sobotics.guttenberg.utils;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -7,6 +9,8 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+import java.util.Scanner;
 
 /**
  * Created by bhargav.h on 30-Sep-16.
@@ -99,5 +103,26 @@ public class FileUtils {
 
     public static void createNewFile(String filename, String data) throws IOException{
         Files.write(Paths.get(filename), Arrays.asList(data), StandardOpenOption.CREATE_NEW,StandardOpenOption.WRITE);
+    }
+    
+    /**
+     * Returns a random line of a file
+     * @author <a href="https://stackoverflow.com/users/27198/itay-maman">Itay Maman</a>
+     * @source <a href="https://stackoverflow.com/a/2218067/4687348">Stack Overflow</a>
+     * */
+    public static String randomLine(File f) throws FileNotFoundException
+    {
+       String result = null;
+       Random rand = new Random();
+       int n = 0;
+       for(Scanner sc = new Scanner(f); sc.hasNext(); )
+       {
+          ++n;
+          String line = sc.nextLine();
+          if(rand.nextInt(n) == 0)
+             result = line;         
+       }
+
+       return result;      
     }
 }

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -315,7 +315,7 @@ public class PostUtils {
 		                );
 		
 		String status = output.get("status").getAsString();
-		if (!status.equalsIgnoreCase("success")) {
+		if (!status.equalsIgnoreCase("success") && ping != null) {
 			String statusMsg = output.get("message").getAsString();
 			if (ping.getMessage().getUser().isRoomOwner()) {
 				ping.getRoom().replyTo(ping.getMessage().getId(), statusMsg);

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -315,7 +315,7 @@ public class PostUtils {
 		                );
 		
 		String status = output.get("status").getAsString();
-		if (!status.equalsIgnoreCase("success") && ping != null) {
+		if (!status.equalsIgnoreCase("success")) {
 			String statusMsg = output.get("message").getAsString();
 			if (ping.getMessage().getUser().isRoomOwner()) {
 				ping.getRoom().replyTo(ping.getMessage().getId(), statusMsg);

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import fr.tunaki.stackoverflow.chat.ChatHost;
 import fr.tunaki.stackoverflow.chat.Message;
 import fr.tunaki.stackoverflow.chat.Room;
 import fr.tunaki.stackoverflow.chat.event.PingMessageEvent;
@@ -256,10 +257,10 @@ public class PostUtils {
 		
 		try {
 			if (CommandUtils.checkForCommand(pingMsg.getContent(), "k") || CommandUtils.checkForCommand(pingMsg.getContent(), "tp")) {
-				PostUtils.storeFeedback(ping, reportId, "tp");
+				PostUtils.storeFeedback(room, ping, reportId, "tp");
 			}
 			if (CommandUtils.checkForCommand(pingMsg.getContent(), "f") || CommandUtils.checkForCommand(pingMsg.getContent(), "fp")) {
-				PostUtils.storeFeedback(ping, reportId, "fp");
+				PostUtils.storeFeedback(room, ping, reportId, "fp");
 			}
 		} catch (IOException e) {
 			LOGGER.error("Could not save feedback!", e);
@@ -303,7 +304,7 @@ public class PostUtils {
 	 * @param reportId The ID of the CopyPastor-Report
 	 * @param feedback tp or fp
 	 * */
-	public static void storeFeedback(PingMessageEvent ping, int reportId, String feedback) throws IOException {
+	public static void storeFeedback(Room room, PingMessageEvent ping, int reportId, String feedback) throws IOException {
 		Properties prop = Guttenberg.getLoginProperties();
 		
 		String url = prop.getProperty("copypastor_url", "http://guttenberg.sobotics.org:5000")+"/feedback/create";
@@ -311,7 +312,7 @@ public class PostUtils {
 						"post_id", ""+reportId,
 						"feedback_type", feedback,
 						"username", ping.getUserName(),
-						"link", "https://chat.stackoverflow.com/users/"+ping.getUserId()
+						"link", "https://chat." + PostUtils.getChatHostAsString(room.getHost()) + "/users/"+ping.getUserId()
 		                );
 		
 		String status = output.get("status").getAsString();
@@ -326,4 +327,21 @@ public class PostUtils {
 			LOGGER.error(statusMsg);
 		} // if
 	} // storeFeedback
+	
+	/**
+	 * Ugly workaround to get <code>ChatHost.getName()</code>, which is not public
+	 * https://github.com/Tunaki/chatexchange/issues/5
+	 * */
+	public static String getChatHostAsString(ChatHost host) {
+		switch (host) {
+			case STACK_OVERFLOW:
+				return "stackoverflow.com";
+			case STACK_EXCHANGE:
+				return "stackexchange.com";
+			case META_STACK_EXCHANGE:
+				return "meta.stackexchange.com";
+			default:
+				return "stackoverflow.com"; 
+		}
+	}
 } // class

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -216,6 +216,7 @@ public class PostUtils {
 		
 		String url = prop.getProperty("copypastor_url", "http://guttenberg.sobotics.org:5000")+"/posts/create";
 		JsonObject output = JsonUtils.post(url,
+						"key", prop.getProperty("copypastor_key", "no_key"),
 		                "url_one","//stackoverflow.com/a/"+target.getAnswerID()+"/4687348",
 		                "url_two","//stackoverflow.com/a/"+original.getAnswerID()+"/4687348",
 		                //"title_one",original.getTitle(),
@@ -309,6 +310,7 @@ public class PostUtils {
 		
 		String url = prop.getProperty("copypastor_url", "http://guttenberg.sobotics.org:5000")+"/feedback/create";
 		JsonObject output = JsonUtils.post(url,
+						"key", prop.getProperty("copypastor_key", "no_key"),
 						"post_id", ""+reportId,
 						"feedback_type", feedback,
 						"username", ping.getUserName(),

--- a/src/main/java/org/sobotics/guttenberg/utils/PrintUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PrintUtils.java
@@ -1,5 +1,7 @@
 package org.sobotics.guttenberg.utils;
 
+import java.util.regex.Pattern;
+
 /**
  * Created by bhargav.h on 11-Sep-16.
  */
@@ -13,6 +15,18 @@ public class PrintUtils {
     		return PrintUtils.printDescription();
     	else
     		return " [ [Guttenberg](http://stackapps.com/q/7197/43403) | [CopyPastor]("+reportLink+") ] ";
+    }
+    /**
+     * The pattern used to find out, if one of Guttenberg's messages is a report
+     * */
+    public static String reportIdRegExPatternString() {
+    	return "\\[ \\[Guttenberg\\].*\\[CopyPastor]\\(.*\\/posts\\/(?'reportId'\\d*)\\)";
+    }
+    /**
+     * The pattern used to find out, if one of Guttenberg's messages is a report
+     * */
+    public static Pattern reportIdRegExPattern() {
+    	return Pattern.compile(PrintUtils.reportIdRegExPatternString());
     }
     public static String printStackAppsPost(){
         return "[Guttenberg - A bot searching for plagiarism on Stack Overflow](http://stackapps.com/q/7197/43403)";


### PR DESCRIPTION
Feedback is now sent to CopyPastor.

New command:
 `feedback <copyPasta id> <tp|k|f|fp>`

Reports now accept `tp` and `fp` as well.

----
closes #103 
closes #13 
  
  