### PR TITLE
Feature/128 chatexchange update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>fr.tunaki.stackoverflow</groupId>
 			<artifactId>chatexchange</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.optimaize.languagedetector</groupId>

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -314,7 +314,7 @@ public class PostUtils {
 						"post_id", ""+reportId,
 						"feedback_type", feedback,
 						"username", ping.getUserName(),
-						"link", "https://chat." + PostUtils.getChatHostAsString(room.getHost()) + "/users/"+ping.getUserId()
+						"link", ping.getMessage().getUser().getProfileLink()
 		                );
 		
 		String status = output.get("status").getAsString();
@@ -333,7 +333,9 @@ public class PostUtils {
 	/**
 	 * Ugly workaround to get <code>ChatHost.getName()</code>, which is not public
 	 * https://github.com/Tunaki/chatexchange/issues/5
+	 * @Deprecated in 1.0; <code>ChatHost.getBaseUrl()</code> now returns the chat-URL
 	 * */
+	@Deprecated
 	public static String getChatHostAsString(ChatHost host) {
 		switch (host) {
 			case STACK_OVERFLOW:


### PR DESCRIPTION
* Use tunaki/chatexchange version `1.1.2-SNAPSHOT`
* **Deprecated:** `PostUtils.getChatHostAsString()`
  * Use `User.getProfileLink()` instead

closes #128
