### PR TITLE
#113: + remove strings like <!-- begin snippet ...

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/entities/Post.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/Post.java
@@ -69,6 +69,18 @@ public class Post {
     public String getBodyMarkdown() {
         return bodyMarkdown;
     }
+    
+    /**
+     * Returns a cleaner Version of the body_markdown
+     * It removes the markdown used to create JS-snippets
+     * */
+    public String getCleanBodyMarkdown() {
+    	String md = this.getBodyMarkdown();
+    	
+    	md.replaceAll("<!-- begin snippet:.*-->|<!-- language:.*-->|<!-- end snippet.*-->", "");
+    	
+    	return md;
+    }
 
     public void setBodyMarkdown(String bodyMarkdown) {
         this.bodyMarkdown = bodyMarkdown;

--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -86,8 +86,8 @@ public class PostMatch implements Comparable<PostMatch>{
         	LOGGER.warn("Could not load quantifiers from general.properties. Using hardcoded", e);
         }
         
-		int lengthOne = this.original.getBodyMarkdown().length();
-		int lengthTwo = this.target.getBodyMarkdown().length();
+		int lengthOne = this.original.getCleanBodyMarkdown().length();
+		int lengthTwo = this.target.getCleanBodyMarkdown().length();
 		
 		return lengthOne >= minimumLength && lengthTwo >= minimumLength;
 	}

--- a/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
@@ -46,10 +46,10 @@ public class ExactParagraphMatch implements Reason {
 		JaroWinkler jw = new JaroWinkler();
 		boolean matched = false;
 		
-		List<String> targetCodePs = PostUtils.getCodeParagraphs(this.target.getBodyMarkdown());
+		List<String> targetCodePs = PostUtils.getCodeParagraphs(this.target.getCleanBodyMarkdown());
 		//System.out.println(targetCodePs);
 		for (Post original : this.originals) {
-			List<String> originalCodePs = PostUtils.getCodeParagraphs(original.getBodyMarkdown());
+			List<String> originalCodePs = PostUtils.getCodeParagraphs(original.getCleanBodyMarkdown());
 			
 			//Loop through targetCodePs
 			for (String targetCode : targetCodePs) {

--- a/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
@@ -39,7 +39,7 @@ public class StringSimilarity implements Reason {
 	}
 	
 	public static double similarityOf(Post targetPost, Post originalPost) {
-		String targetBodyMarkdown = targetPost.getBodyMarkdown();
+		String targetBodyMarkdown = targetPost.getCleanBodyMarkdown();
         String targetCodeOnly = targetPost.getCodeOnly();
         String targetPlaintext = targetPost.getPlaintext();
         String targetQuotes = targetPost.getQuotes();
@@ -67,7 +67,7 @@ public class StringSimilarity implements Reason {
         
         JaroWinkler jw = new JaroWinkler();
         
-        String originalBodyMarkdown = originalPost.getBodyMarkdown();
+        String originalBodyMarkdown = originalPost.getCleanBodyMarkdown();
         String originalCodeOnly = originalPost.getCodeOnly();
         String originalPlaintext = originalPost.getPlaintext();
         String originalQuotes = originalPost.getQuotes();


### PR DESCRIPTION
Strings matching the following RegEx will be removed before comparing the posts:
`<!-- begin snippet:.*-->|<!-- language:.*-->|<!-- end snippet.*-->`

fixes #113 