### PR TITLE
Feature/131 blacklist users for commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>fr.tunaki.stackoverflow</groupId>
 			<artifactId>chatexchange</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.optimaize.languagedetector</groupId>

--- a/src/main/java/org/sobotics/guttenberg/clients/Client.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Client.java
@@ -80,6 +80,7 @@ public class Client {
         DataService redundaData = redunda.buildDataService();
         redundaData.trackFile(FilePathUtils.optedUsersFile);
         redundaData.trackFile(FilePathUtils.generalPropertiesFile);
+        redundaData.trackFile(FilePathUtils.blacklistedUsersFile);
         
         if (productionInstance.equals("false")) {
         	redunda.setDebugging(true);

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -2,7 +2,6 @@ package org.sobotics.guttenberg.commandlists;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,8 +31,10 @@ public class SoBoticsCommandsList {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SoBoticsCommandsList.class);
 
 	public void mention(Room room, PingMessageEvent event, boolean isReply, RunnerService instance) {
-		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl()))
+		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl())) {
+			LOGGER.info("Blacklisted user " + event.getUserName() + " replied to the bot.");
 			return;
+		}
 		
 		Message message = event.getMessage();
 		LOGGER.info("Mention: " + message.getContent());

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.sobotics.redunda.PingService;
 import org.sobotics.guttenberg.commands.*;
 import org.sobotics.guttenberg.services.RunnerService;
+import org.sobotics.guttenberg.utils.CheckUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
 import org.sobotics.guttenberg.utils.FileUtils;
 
@@ -31,10 +32,9 @@ public class SoBoticsCommandsList {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SoBoticsCommandsList.class);
 
 	public void mention(Room room, PingMessageEvent event, boolean isReply, RunnerService instance) {
-		/*
-		 * if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId())) return;
-		 */
-
+		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl()))
+			return;
+		
 		Message message = event.getMessage();
 		LOGGER.info("Mention: " + message.getContent());
 		List<SpecialCommand> commands = new ArrayList<>(Arrays.asList(

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -37,7 +37,7 @@ public class SoBoticsCommandsList {
 		}
 		
 		Message message = event.getMessage();
-		LOGGER.info("Mention: " + message.getContent());
+		LOGGER.info("Mention by " + event.getUserId() + ": " + message.getContent());
 		List<SpecialCommand> commands = new ArrayList<>(Arrays.asList(
 				new Alive(message),
 				new CheckInternet(message),

--- a/src/main/java/org/sobotics/guttenberg/utils/CheckUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/CheckUtils.java
@@ -1,0 +1,22 @@
+package org.sobotics.guttenberg.utils;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CheckUtils {
+	private static final Logger LOGGER = LoggerFactory.getLogger(CheckUtils.class);
+	
+	/**
+	 * Checks if a user is blacklisted on a certain site
+	 * */
+	public static boolean checkIfUserIsBlacklisted(long userId, String host){
+		try {
+			return FileUtils.checkIfInFile(FilePathUtils.blacklistedUsersFile, host + ":" + String.valueOf(userId));
+		} catch (IOException e) {
+			LOGGER.error("Could not check if user is blacklisted! Assuming, he's not...", e);
+			return false;
+		}
+    }
+}

--- a/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
@@ -4,4 +4,5 @@ public class FilePathUtils {
 	public static String generalPropertiesFile = "./properties/general.properties";
     public static String loginPropertiesFile = "./properties/login.properties";
     public static String optedUsersFile = "./data/OptedInUsersList.txt";
+    public static String blacklistedUsersFile = "./data/BlacklistedUsersList.txt";
 }

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -133,10 +133,9 @@ public class PostUtils {
 		Message parentMessage = room.getMessage(event.getParentMessageId());
 		long parentMessageId = parentMessage.getId();
 		System.out.println(message.getContent());
-		/*
-		 * if (CheckUtils.checkIfUserIsBlacklisted(event.getUserId())){
-		 * System.out.println("Blacklisted user"); return; }
-		 */
+		
+		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl()))
+			return;
 		
 		PostUtils.checkPingForFeedback(room, event);
 		

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -309,7 +309,7 @@ public class PostUtils {
 						"post_id", ""+reportId,
 						"feedback_type", feedback,
 						"username", ping.getUserName(),
-						"link", "https://chat." + PostUtils.getChatHostAsString(room.getHost()) + "/users/"+ping.getUserId()
+						"link", ping.getMessage().getUser().getProfileLink()
 		                );
 		
 		String status = output.get("status").getAsString();
@@ -328,7 +328,9 @@ public class PostUtils {
 	/**
 	 * Ugly workaround to get <code>ChatHost.getName()</code>, which is not public
 	 * https://github.com/Tunaki/chatexchange/issues/5
+	 * @Deprecated in 1.0; <code>ChatHost.getBaseUrl()</code> now returns the chat-URL
 	 * */
+	@Deprecated
 	public static String getChatHostAsString(ChatHost host) {
 		switch (host) {
 			case STACK_OVERFLOW:

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -134,8 +134,10 @@ public class PostUtils {
 		long parentMessageId = parentMessage.getId();
 		System.out.println(message.getContent());
 		
-		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl()))
+		if(CheckUtils.checkIfUserIsBlacklisted(event.getUserId(), room.getHost().getBaseUrl())) {
+			LOGGER.info("Blacklisted user " + event.getUserName() + " replied to the bot.");
 			return;
+		}
 		
 		PostUtils.checkPingForFeedback(room, event);
 		


### PR DESCRIPTION
Users can now be blacklisted by adding a line in `data/BlacklistedUsersList.txt`.

Example: Blacklist user-ID `248139` on SE-chat
```
https://chat.stackexchange.com:248139
```

The file is synced via Redunda.

----

closes #131 