### PR TITLE
Feature/154 copypastor reasons

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -23,6 +23,7 @@ public class PostMatch implements Comparable<PostMatch>{
 	private Post original;
 	private List<String> reasons = new ArrayList<String>();
 	private double totalScore = 0;
+	private String copyPastorReasonString = "";
 	
 	public PostMatch(Post targetPost, Post originalPost) {
 		this.target = targetPost;
@@ -37,16 +38,6 @@ public class PostMatch implements Comparable<PostMatch>{
 		return this.original;
 	}
 	
-	@Deprecated
-	public void addReason(Reason reason) {
-		if (!reasons.contains(reason.description())) {
-			//add reason
-			this.reasons.add(reason.description());
-			//add score
-			this.totalScore += reason.score();
-		}
-	}
-	
 	public void addReason(String reason, double score) {
 		if (!reasons.contains(reason)) {
 			//add reason
@@ -56,8 +47,19 @@ public class PostMatch implements Comparable<PostMatch>{
 		}
 	}
 	
+	public void addReasonToCopyPastorString(String reason, double score) {
+		if (!reasons.contains(reason)) {
+			double roundedScore = Math.round(score*100.0)/100.0;
+			this.copyPastorReasonString += "," + reason + ":" + roundedScore;
+		}
+	}
+	
 	public List<String> getReasonStrings() {
 		return this.reasons;
+	}
+	
+	public String getCopyPastorReasonString() {
+		return this.copyPastorReasonString;
 	}
 	
 	public double getTotalScore() {

--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -50,7 +50,11 @@ public class PostMatch implements Comparable<PostMatch>{
 	public void addReasonToCopyPastorString(String reason, double score) {
 		if (!reasons.contains(reason)) {
 			double roundedScore = Math.round(score*100.0)/100.0;
-			this.copyPastorReasonString += "," + reason + ":" + roundedScore;
+			
+			if (copyPastorReasonString.length() > 0)
+				this.copyPastorReasonString += ",";
+			
+			this.copyPastorReasonString += reason + ":" + roundedScore;
 		}
 	}
 	

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -178,6 +178,8 @@ public class PlagFinder {
     						alreadyExists = true;
     						existingMatch.addReason(reason.description(i), scores.get(n));
     						
+    						existingMatch.addReasonToCopyPastorString(reason.description(i, false), scores.get(n));
+    						
     						matches.set(i, existingMatch);
     					}
     					

--- a/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
+++ b/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
@@ -41,7 +41,7 @@ public class SoBoticsPostPrinter implements PostPrinter {
 		double roundedTotalScore = Math.round(match.getTotalScore()*100.0)/100.0;
 		
 		try {
-			reportLink = PostUtils.storeReport(match.getTarget(), match.getOriginal());
+			reportLink = PostUtils.storeReport(match);
 		}
 		catch (IOException e) {
 			LOGGER.warn(e.getMessage());

--- a/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
@@ -27,6 +27,8 @@ public class ExactParagraphMatch implements Reason {
 	private List<Double> scoreList = new ArrayList<Double>();
 	private double score = -1;
 	
+	public static final String LABEL = "Exact paragraph match";
+	
 	public ExactParagraphMatch(Post target, List<Post> originalPosts) {
 		this.target = target;
 		this.originals = originalPosts;
@@ -74,15 +76,20 @@ public class ExactParagraphMatch implements Reason {
 		
 		return matched;
 	}
-
-	@Override
-	public String description() {
-		return "Exact paragraph match";
-	}
 	
 	@Override
 	public String description(int index) {
-		return "Exact paragraph match";
+		return LABEL;
+	}
+	
+	@Override
+	public String description(int index, boolean includingScore) {
+		if (includingScore) {
+			double roundedScore = Math.round(this.scoreList.get(index)*100.0)/100.0;
+			return score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+		} else {
+			return LABEL;
+		}
 	}
 
 	@Override

--- a/src/main/java/org/sobotics/guttenberg/reasons/Reason.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/Reason.java
@@ -18,19 +18,21 @@ public interface Reason {
 	/**
 	 * The description of the reason
 	 * 
-	 * @return a short description of the reason like "String similarity"
-	 * */
-	@Deprecated
-	public String description();
-	
-	/**
-	 * The description of the reason
-	 * 
 	 * @parameter index The index in the `matchedPosts()`-array
 	 * 
 	 * @return a short description of the reason like "String similarity"
 	 * */
 	public String description(int index);
+	
+	/**
+	 * The description of the reason
+	 * 
+	 * @parameter index The index in the `matchedPosts()`-array
+	 * @parameter includingScore if false, the score won't be included in the description
+	 * 
+	 * @return a short description of the reason like "String similarity"
+	 * */
+	String description(int index, boolean includingScore);
 	
 	/**
 	 * The score that specific reason reached. This has no influence on whether a post is reported or not.

--- a/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
@@ -27,6 +27,8 @@ public class StringSimilarity implements Reason {
 	private double score = -1;
 	private boolean ignoringScore = false;
 	
+	public static final String LABEL = "String similarity";
+	
 	public StringSimilarity(Post target, List<Post> originalPosts) {
 		this.target = target;
 		this.originals = originalPosts;
@@ -136,17 +138,20 @@ public class StringSimilarity implements Reason {
 		
 		return matched;
 	}
-
-	@Override
-	public String description() {
-		double roundedScore = Math.round(this.score()*100.0)/100.0;
-		return score() >= 0 ? "String similarity "+roundedScore : "String similarity";
-	}
 	
 	@Override
 	public String description(int index) {
-		double roundedScore = Math.round(this.scoreList.get(index)*100.0)/100.0;
-		return score() >= 0 ? "String similarity "+roundedScore : "String similarity";
+		return description(index, true);
+	}
+	
+	@Override
+	public String description(int index, boolean includingScore) {
+		if (includingScore) {
+			double roundedScore = Math.round(this.scoreList.get(index)*100.0)/100.0;
+			return score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+		} else {
+			return LABEL;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The reasons and scores will now be sent to CopyPastor.

`PostUtils.storeReport(Post target, Post original)` is now deprecated and will be replaced by `PostUtils.storeReport(PostMatch match)`

----

fixes #154 