### PR TITLE
Bugfix/143 not reporting reposts

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -9,7 +9,6 @@ import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sobotics.guttenberg.reasons.Reason;
 import org.sobotics.guttenberg.utils.FilePathUtils;
 
 /**
@@ -105,8 +104,8 @@ public class PostMatch implements Comparable<PostMatch>{
 		boolean minimumTimeSpanChecked = minutes >= 5;
 		
 		//#130: Time-span for reposts: 0 minutes
-		if (this.target.getAnswerID() == this.original.getAnswerID())
-			minimumTimeSpanChecked = minutes >= 0;
+		if (this.isRepost())
+			minimumTimeSpanChecked = targetCreation.getEpochSecond() > originalCreation.getEpochSecond();
 		
 		return lengthOne >= minimumLength && lengthTwo >= minimumLength && minimumTimeSpanChecked;
 	}

--- a/src/main/java/org/sobotics/guttenberg/utils/ApiUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/ApiUtils.java
@@ -21,7 +21,7 @@ public class ApiUtils {
     }
     
     public static JsonObject getLinkedQuestionsById(Integer questionId, String site, String apiKey) throws IOException{
-        String questionIdUrl = "https://api.stackexchange.com/2.2/questions/"+questionId+"/related";
+        String questionIdUrl = "https://api.stackexchange.com/2.2/questions/"+questionId+"/linked";
         return JsonUtils.get(questionIdUrl,"site",site,"key",apiKey);
     }
     


### PR DESCRIPTION
Two pieces of code might have been involved here:

* The Api-Methods for fetching linked and related questions both queried `/related` 😂 <sub>(stupid copy-paste :-P )</sub>
* The time-span between posts was calculated in minutes. If the difference was 0 minutes or more, the past was reported. Now I'm just checking, if the timestamp of the target in seconds is larger than of the original post

Tests with low minimum-scores showed, that reposts will finally be reported again: https://chat.stackexchange.com/transcript/message/43055277#43055277

----
fixes #143 