### PR TITLE
- added debug output to show reasons posted to CP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>de.felixsfd.stackoverflow</groupId>
 	<artifactId>guttenberg</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -248,7 +248,7 @@ public class PostUtils {
 		                "score", ""+match.getTotalScore(),
 		                "reasons", match.getCopyPastorReasonString());
 		
-		LOGGER.debug(match.getCopyPastorReasonString());
+		System.out.println(match.getCopyPastorReasonString());
 		
 		return prop.getProperty("copypastor_url", "http://localhost:5000") + "/posts/" + output.get("post_id").getAsString();
 	}

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -248,6 +248,8 @@ public class PostUtils {
 		                "score", ""+match.getTotalScore(),
 		                "reasons", match.getCopyPastorReasonString());
 		
+		LOGGER.debug(match.getCopyPastorReasonString());
+		
 		return prop.getProperty("copypastor_url", "http://localhost:5000") + "/posts/" + output.get("post_id").getAsString();
 	}
 	


### PR DESCRIPTION
Added debug output to inspect, why CopyPastor doesn't receive the `ExactParagraphMatch`-reason.