### PR TITLE
Improved logging

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/clients/Client.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Client.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.redunda.DataService;
@@ -35,8 +37,22 @@ public class Client {
     }
     
     public static void main(String[] args) {
-        LOGGER.info("Hello, World!");
-        LOGGER.info("Load properties...");
+    	Properties loggerProperties = new Properties();
+    	try{
+    		loggerProperties.load(new FileInputStream(FilePathUtils.loggerPropertiesFile));
+    		
+    		String levelStr = loggerProperties.getProperty("level");
+    		Level newLevel = Level.toLevel(levelStr, Level.ERROR);
+    		LogManager.getRootLogger().setLevel(newLevel);
+        }
+        catch (Throwable e){
+            LOGGER.error("Could not load logger.properties! Using default log-level ERROR.", e);
+        }
+    	
+        LOGGER.info("============================");
+        LOGGER.info("=== Launching Guttenberg ===");
+        LOGGER.info("============================");
+        LOGGER.info("Loading properties...");
         
         Properties prop = new Properties();
 
@@ -52,7 +68,7 @@ public class Client {
         
         Guttenberg.setLoginProperties(prop);
         
-        LOGGER.info("Initialize chat...");
+        LOGGER.info("Initializing chat...");
         StackExchangeClient seClient = new StackExchangeClient(prop.getProperty("email"), prop.getProperty("password"));
         
         List<BotRoom> rooms = new ArrayList<>();
@@ -66,6 +82,7 @@ public class Client {
             InputStream is = Status.class.getResourceAsStream("/guttenberg.properties");
             guttenbergProperties.load(is);
             version = guttenbergProperties.getProperty("version", "0.0.0");
+            LOGGER.info("Running on version " + version);
         }
         catch (IOException e){
             LOGGER.error("Could not load properties", e);
@@ -100,7 +117,7 @@ public class Client {
         redunda.start();
         
         
-        LOGGER.info("Launch Guttenberg...");
+        LOGGER.debug("Initialize RunnerService...");
         
         RunnerService runner = new RunnerService(seClient, rooms);
         

--- a/src/main/java/org/sobotics/guttenberg/clients/Client.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Client.java
@@ -124,7 +124,7 @@ public class Client {
         runner.start();
         
         StatusUtils.startupDate = Instant.now();
-        LOGGER.info(StatusUtils.startupDate + " - Successfully launched Guttenberg!");
+        LOGGER.info("Successfully launched Guttenberg!");
     }
 
 }

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -51,13 +51,13 @@ public class Guttenberg {
 	public void execute() throws Throwable {
 		boolean standbyMode = PingService.standby.get();
 		if (standbyMode == true) {
-			LOGGER.info("STANDBY - " + Instant.now());
+			LOGGER.info("STANDBY - Abort execute()");
 			return;
 		}
 		
 		Instant startTime = Instant.now();
 		Properties props = new Properties();
-		LOGGER.info("Executing at - "+startTime);
+		LOGGER.info("Starting Guttenberg.execute() ...");
 		
 		try {
 			props.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
@@ -138,7 +138,7 @@ public class Guttenberg {
 		
 		StatusUtils.lastSucceededExecutionStarted = startTime;
 		StatusUtils.lastExecutionFinished = Instant.now();
-		LOGGER.info("Finished at - "+StatusUtils.lastExecutionFinished);
+		LOGGER.info("Guttenberg.execute() finished");
 	}
 
 	public static Properties getLoginProperties() {

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -44,7 +44,7 @@ public class Guttenberg {
 		try {
 			execute();
 		} catch (Throwable e) {
-			LOGGER.error("Error throws in execute()", e);
+			LOGGER.error("Error thrown in execute()", e);
 		}
 	}
 	
@@ -95,23 +95,23 @@ public class Guttenberg {
 			return;
 		}
 		
-		LOGGER.info("Add the answers to the PlagFinders...");
+		LOGGER.debug("Add the answers to the PlagFinders...");
 		//add relatedAnswers to the PlagFinders
 		for (PlagFinder finder : plagFinders) {
 			Integer targetId = finder.getTargetAnswerId();
-			//System.out.println("TargetID: "+targetId);
+			LOGGER.trace("Check targetID: " + targetId);
 			
 			for (Post relatedItem : relatedAnswersUnsorted) {
-				//System.out.println(relatedItem);
+				LOGGER.trace("Related item: " + relatedItem);
 				if (relatedItem.getAnswerID() != null && relatedItem.getAnswerID() != targetId) {
 					finder.relatedAnswers.add(relatedItem);
-					//System.out.println("Added answer: "+relatedItem);
+					LOGGER.trace("Added answer: " + relatedItem);
 				}
 			}
 		}
 		
-		LOGGER.info("There are "+plagFinders.size()+" PlagFinders");
-		LOGGER.info("Find the duplicates...");
+		LOGGER.debug("There are "+plagFinders.size()+" PlagFinders");
+		LOGGER.debug("Find the duplicates...");
 		//Let PlagFinders find the best match
 		List<PostMatch> allMatches = new ArrayList<PostMatch>();
 		for (PlagFinder finder : plagFinders) {

--- a/src/main/java/org/sobotics/guttenberg/clients/Updater.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Updater.java
@@ -34,7 +34,7 @@ public class Updater {
             LOGGER.error("Could not load properties", e);
         }
         
-        LOGGER.info("Loaded properties");
+        LOGGER.debug("Loaded properties");
         
         String versionString = guttenbergProperties.getProperty("version", "0.0.0");
         this.currentVersion = new Version(versionString);
@@ -49,24 +49,23 @@ public class Updater {
         for (File file : files) {
             if (file.isFile()) {
                 String name = file.getName();
-                //LOGGER.info("File: "+name);
+                LOGGER.debug("File: "+name);
                 Matcher matcher = pattern.matcher(name);
                 matcher.find();
-                //LOGGER.info("Init matcher");
+                LOGGER.debug("Init matcher");
                 String v = "";
                 
                 try {
                     v = matcher.group(1);
                 } catch (Exception e) {
-                    //LOGGER.error("ERROR", e);
+                    LOGGER.warn("Filename " + name + " didn't match the pattern.", e);
                 }
                 
                 
-                //LOGGER.info("Matched");
                 if (v != null && v.length() > 0) {
-
+                	LOGGER.debug("Matched");
                     Version version = new Version(v);
-                    
+                    LOGGER.debug("Found version " + version.get());
                     if (this.currentVersion.compareTo(version) == -1) {
                         //higher than current version
                         if (this.newVersion.compareTo(version) == -1) {

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -45,6 +45,7 @@ public class SoBoticsCommandsList {
 				new Check(message), 
 				new ClearHelp(message),
 				new Feedback(message, event, room),
+				new LogLevel(message),
 				//new OptIn(message),
 				//new OptOut(message), 
 				new Quota(message), 

--- a/src/main/java/org/sobotics/guttenberg/commands/Alive.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Alive.java
@@ -30,7 +30,7 @@ public class Alive implements SpecialCommand {
 
     @Override
     public void execute(Room room, RunnerService instance) {  
-    	LOGGER.info("Someone wants to know, if I'm alive");
+    	LOGGER.warn("Someone wants to know, if I'm alive");
         room.send("The instance "+PingService.location+ " is running.\nStandby: "+PingService.standby.toString());
     }
 

--- a/src/main/java/org/sobotics/guttenberg/commands/Check.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Check.java
@@ -40,11 +40,7 @@ public class Check implements SpecialCommand {
     @Override
     public void execute(Room room, RunnerService instance) {
         String word = CommandUtils.extractData(message.getPlainContent()).trim();
-        Integer returnValue = 0;
-
-        if(word.contains(" ")){
-            String parts[] = word.split(" ");
-        }
+        
         if(word.contains("/"))
         {                
             word = CommandUtils.getAnswerId(word);
@@ -65,9 +61,12 @@ public class Check implements SpecialCommand {
         try {
             JsonObject answer = ApiUtils.getAnswerDetailsById(answerId, "stackoverflow", prop.getProperty("apikey", ""));
             JsonObject target = answer.get("items").getAsJsonArray().get(0).getAsJsonObject();
+            LOGGER.trace("Checking answer: " + target.toString());
             PlagFinder finder = new PlagFinder(target);
             finder.collectData();
             List<PostMatch> matches = finder.matchesForReasons(true);
+            
+            LOGGER.trace("Found " + matches.size() + " PostMatches");
             
             if (matches.size() > 0) {
             	//sort the matches
@@ -91,7 +90,7 @@ public class Check implements SpecialCommand {
             	room.replyTo(message.getId(), "No similar posts found.");
             }
         } catch (IOException e) {
-            LOGGER.error("ERROR", e);
+            LOGGER.error("Error while executing the \"check\"-command!", e);
         }
     }
 

--- a/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
@@ -57,11 +57,13 @@ public class Feedback implements SpecialCommand {
         try {
         	reportId = Integer.parseInt(word);
         } catch (Exception e) {
-        	LOGGER.info("Invalid report-ID", e);
+        	LOGGER.warn("Invalid report-ID", e);
         }
         
         if (reportId == -1)
         	return;
+        
+        LOGGER.debug("Sending feedback " + type + " for report " + reportId);
         
         try {
 			if (type.equalsIgnoreCase("tp") || type.equalsIgnoreCase("k")) {

--- a/src/main/java/org/sobotics/guttenberg/commands/Kill.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Kill.java
@@ -1,5 +1,7 @@
 package org.sobotics.guttenberg.commands;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.CommandUtils;
 
@@ -9,6 +11,8 @@ import fr.tunaki.stackoverflow.chat.User;
 
 public class Kill implements SpecialCommand {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(Kill.class);
+	
 	private static final String CMD = "kill";
 	private final Message message;
     
@@ -26,11 +30,12 @@ public class Kill implements SpecialCommand {
 		User user = message.getUser();
     	
     	if (!user.isModerator() && !user.isRoomOwner()) {
+    		LOGGER.warn("User " + user.getName() + " tried to kill the bot!");
     		room.replyTo(message.getId(), "Sorry, but only room-owners and moderators can use this command (@FelixSFD)");
     		return;
     	}
     	
-    	System.out.println("KILLED BY "+user.getName());
+    	LOGGER.error("KILLED BY "+user.getName());
     	System.exit(0);
 	}
 

--- a/src/main/java/org/sobotics/guttenberg/commands/LogLevel.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/LogLevel.java
@@ -1,0 +1,115 @@
+package org.sobotics.guttenberg.commands;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Properties;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sobotics.guttenberg.services.RunnerService;
+import org.sobotics.guttenberg.utils.CommandUtils;
+import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.redunda.PingService;
+
+import fr.tunaki.stackoverflow.chat.Message;
+import fr.tunaki.stackoverflow.chat.Room;
+import fr.tunaki.stackoverflow.chat.User;
+
+public class LogLevel implements SpecialCommand {
+	private static final Logger LOGGER = LoggerFactory.getLogger(LogLevel.class);
+	
+	private static final String CMD = "log";
+    private final Message message;
+
+    public LogLevel(Message message) {
+        this.message = message;
+    }
+
+    @Override
+    public boolean validate() {
+        return CommandUtils.checkForCommand(message.getPlainContent(), CMD);
+    }
+
+    @Override
+    public void execute(Room room, RunnerService instance) {
+    	User user = message.getUser();
+    	
+    	if (!user.isModerator() && !user.isRoomOwner()) {
+    		LOGGER.warn("User " + user.getName() + " tried to change the logging-level!");
+    		room.replyTo(message.getId(), "You are not allowed to change the logging-level.");
+    		return;
+    	}
+    	
+    	String allowedLevels = "error|warn|info|debug|trace";
+    	String levelString = "warn";
+    	String instanceParam = null;
+        String paramString = CommandUtils.extractData(message.getPlainContent());
+        String[] params = paramString.split(" ");
+        
+        LOGGER.debug(params.length + " parameters");
+        
+        if (params.length == 1) {
+        	if (params[0].matches(allowedLevels)) {
+        		//No instance given
+        		levelString = params[0];
+        		LOGGER.debug("No instance specified. Changing level on all instances...");
+        	} else {
+        		//Not a valid level
+        		room.replyTo(message.getId(), params[0] + " is not a valid logging-level!");
+        		LOGGER.debug(params[0] + " is not a valid logging-level!");
+        		return;
+        	}
+        } else if (params.length == 2) {
+        	//when two arguments are passed, the first one is the instance-name
+        	instanceParam = params[0];
+        	
+        	if (params[1].matches(allowedLevels)) {
+        		levelString = params[1];
+        	} else {
+        		//Not a valid level
+        		room.replyTo(message.getId(), params[1] + " is not a valid logging-level!");
+        		return;
+        	}
+        } else {
+        	room.replyTo(message.getId(), "Invalid number of arguments!");
+        	return;
+        }
+        
+        LOGGER.debug("Level " + levelString + " found.");
+        
+        if (instanceParam == null || instanceParam.equalsIgnoreCase(PingService.location)) {
+        	//the logging-level for this instance should be changed
+        	Level newLevel = Level.toLevel(levelString);
+        	LogManager.getRootLogger().setLevel(newLevel);
+        	
+        	try {
+        		Properties loggingProp = new Properties();
+        		loggingProp.load(new FileInputStream(FilePathUtils.loggerPropertiesFile));
+        		loggingProp.setProperty("level", levelString.toLowerCase());
+        		loggingProp.store(new FileOutputStream(FilePathUtils.loggerPropertiesFile), null);
+        	} catch (Exception e) {
+        		LOGGER.error("Error while saving the new log-level to the logging.properties", e);
+        	}
+        	
+        	LOGGER.info("Logging-level successfully changed to " + levelString);
+        	room.send("Instance *" + PingService.location + "* is now using the logging-level **" + levelString.toUpperCase() + "**");
+        }
+    }
+
+    @Override
+    public String description() {
+        return "Sets the logging-level. Usage: log <instance> <error|warn|info|debug|trace>";
+    }
+
+    @Override
+    public String name() {
+        return CMD;
+    }
+
+	@Override
+	public boolean availableInStandby() {
+		return true;
+	}
+}

--- a/src/main/java/org/sobotics/guttenberg/commands/Reboot.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Reboot.java
@@ -5,6 +5,8 @@ import java.util.Properties;
 import java.io.InputStream;
 
 import org.sobotics.guttenberg.utils.CommandUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.services.RunnerService;
 
 import fr.tunaki.stackoverflow.chat.Message;
@@ -16,6 +18,9 @@ import fr.tunaki.stackoverflow.chat.User;
  * @author owen
  */
 public class Reboot implements SpecialCommand {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(Reboot.class);
+	
 	private static final String CMD = "reboot";
     private final Message message;
     
@@ -33,12 +38,13 @@ public class Reboot implements SpecialCommand {
     	User user = message.getUser();
     	
     	if (!user.isModerator() && !user.isRoomOwner()) {
+    		LOGGER.warn("User " + user.getName() + " tried to reboot the bot!");
     		room.replyTo(message.getId(), "Sorry, but only room-owners and moderators can use this command (@FelixSFD)");
     		return;
     	}
     	
     	
-        System.out.println("REBOOT COMMAND");
+        LOGGER.warn("REBOOT COMMAND executed by " + user.getName());
         String[] args = message.getPlainContent().split(" ");
         if (args.length >= 3) {
             String rebootType = args[2];
@@ -71,19 +77,22 @@ public class Reboot implements SpecialCommand {
     }
     
     private void hardReboot(Room room) {
+    	LOGGER.warn("Hard reboot...");
         try {
             Properties properties = new Properties();
             InputStream is = Status.class.getResourceAsStream("/guttenberg.properties");
             properties.load(is);
 
             String versionString = (String)properties.get("version");
+            
+            LOGGER.info("Booting version " + versionString);
 
             Runtime.getRuntime().exec("nohup java -cp guttenberg-" + versionString + ".jar org.sobotics.guttenberg.clients.Client");
             System.exit(0);
         }
         catch (IOException e) {
-            e.printStackTrace();
-            room.replyTo(message.getId(), "**Reboot failed:** '" + e.getMessage() + "'.");
+            LOGGER.error("Hard reboot failed!", e);
+            room.replyTo(message.getId(), "**Reboot failed!** (cc @FelixSFD)");
         }
     }
 

--- a/src/main/java/org/sobotics/guttenberg/commands/Update.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Update.java
@@ -1,5 +1,7 @@
 package org.sobotics.guttenberg.commands;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.clients.Updater;
 import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.CommandUtils;
@@ -8,6 +10,8 @@ import fr.tunaki.stackoverflow.chat.Message;
 import fr.tunaki.stackoverflow.chat.Room;
 
 public class Update implements SpecialCommand {
+	private static final Logger LOGGER = LoggerFactory.getLogger(Update.class);
+	
 	private static final String CMD = "update";
     private final Message message;
 
@@ -22,15 +26,15 @@ public class Update implements SpecialCommand {
 
     @Override
     public void execute(Room room, RunnerService instance) {
-        System.out.println("Load updater...");
+        LOGGER.info("Load updater...");
         Updater updater = new Updater();
-        System.out.println("Check for updates...");
+        LOGGER.info("Check for updates...");
         
         boolean update = false;
         try {
             update = updater.updateIfAvailable(); 
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            LOGGER.error("Update failed!", e);
             room.replyTo(message.getId(), "Update failed!");
         }
         
@@ -44,7 +48,7 @@ public class Update implements SpecialCommand {
         try {
             wait(10);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOGGER.error("Error while waiting for shutdown!", e);
         }
         System.exit(0);
     }

--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -47,13 +47,16 @@ public class PostMatch implements Comparable<PostMatch>{
 	}
 	
 	public void addReasonToCopyPastorString(String reason, double score) {
+		LOGGER.trace("Adding reason \"" + reason + "\" (Score: " + score + ") to string for CopyPastor");
 		if (!reasons.contains(reason)) {
+			LOGGER.trace("Reason doesn't exist in string yet");
 			double roundedScore = Math.round(score*100.0)/100.0;
 			
 			if (copyPastorReasonString.length() > 0)
 				this.copyPastorReasonString += ",";
 			
 			this.copyPastorReasonString += reason + ":" + roundedScore;
+			LOGGER.trace("New copyPastorReasonString: " + this.copyPastorReasonString);
 		}
 	}
 	
@@ -107,6 +110,11 @@ public class PostMatch implements Comparable<PostMatch>{
 		if (this.isRepost())
 			minimumTimeSpanChecked = targetCreation.getEpochSecond() > originalCreation.getEpochSecond();
 		
+		LOGGER.trace("minimumTimeSpanChecked: " + minimumTimeSpanChecked);
+		LOGGER.trace("Minimum length: " + minimumLength);
+		LOGGER.trace("Length one: " + lengthOne);
+		LOGGER.trace("Length two: " + lengthTwo);
+			
 		return lengthOne >= minimumLength && lengthTwo >= minimumLength && minimumTimeSpanChecked;
 	}
 

--- a/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
@@ -50,7 +50,7 @@ public class NewAnswersFinder {
             //fetched answers
             
             JsonArray items = apiResult.get("items").getAsJsonArray();
-            //System.out.println(items);
+            LOGGER.trace("New answers:\n" + items.toString());
             LOGGER.info("findRecentAnswers() done with "+items.size()+" items");
             List<Post> posts = new ArrayList<Post>();
             

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -59,13 +59,13 @@ public class PlagFinder {
     public void collectData() {
         this.relatedAnswers = new ArrayList<Post>();
         this.fetchRelatedAnswers();
-        LOGGER.info("RelatedAnswers: "+this.relatedAnswers.size());
+        LOGGER.debug("Number of related answers: "+this.relatedAnswers.size());
     }
     
     private void fetchRelatedAnswers() {
         int targetId = this.targetAnswer.getQuestionID();
         int targetAnswerId = this.targetAnswer.getAnswerID();
-        LOGGER.info("Target: "+targetId);
+        LOGGER.debug("Fetching related answers to: "+targetId);
         Properties prop = new Properties();
 
         try{
@@ -79,18 +79,19 @@ public class PlagFinder {
         try {
             JsonObject relatedQuestions = ApiUtils.getRelatedQuestionsById(targetId, "stackoverflow", prop.getProperty("apikey", ""));
             JsonObject linkedQuestions = ApiUtils.getLinkedQuestionsById(targetId, "stackoverflow", prop.getProperty("apikey", ""));
-            //System.out.println("Answer: "+relatedQuestions);
+            LOGGER.trace("Related questions: "+relatedQuestions);
+            LOGGER.trace("Linked questions: "+linkedQuestions);
             String relatedIds = targetId+";";
 
             for (JsonElement question : relatedQuestions.get("items").getAsJsonArray()) {
                 int id = question.getAsJsonObject().get("question_id").getAsInt();
-                //System.out.println("Add: "+id);
+                LOGGER.trace("Add: "+id);
                 relatedIds += id+";";
             }
             
             for (JsonElement question : linkedQuestions.get("items").getAsJsonArray()) {
                 int id = question.getAsJsonObject().get("question_id").getAsInt();
-                //System.out.println("Add: "+id);
+                LOGGER.trace("Add: "+id);
                 relatedIds += id+";";
             }
             
@@ -98,14 +99,14 @@ public class PlagFinder {
                 relatedIds = relatedIds.substring(0, relatedIds.length()-1);
                 
                 
-                LOGGER.info("Related question IDs: "+relatedIds);
-                LOGGER.info("Fetching all answers...");
+                LOGGER.debug("Related question IDs: "+relatedIds);
+                LOGGER.debug("Fetching all answers...");
                 
                 JsonObject relatedAnswers = ApiService.defaultService.getAnswersToQuestionsByIdString(relatedIds);
-                //JsonObject relatedAnswers = ApiUtils.getAnswersToQuestionsByIdString(relatedIds, "stackoverflow", prop.getProperty("apikey", ""));
-                //System.out.println(relatedAnswers);
+                
                 for (JsonElement answer : relatedAnswers.get("items").getAsJsonArray()) {
                     JsonObject answerObject = answer.getAsJsonObject();
+                    LOGGER.trace("Related answer: " + answer);
                     Post answerPost = PostUtils.getPost(answerObject);
                     
                     int answerId = answerPost.getAnswerID();
@@ -154,7 +155,7 @@ public class PlagFinder {
     	ReasonList reasonList = new SOBoticsReasonList(this.targetAnswer, this.relatedAnswers);
     	
     	for (Reason reason : reasonList.reasons(ignoringScores)) {
-    		//LOGGER.info("Checking reason "+reason.description()+"\nIgnoring score: "+ignoringScores);
+    		LOGGER.debug("Checking reasons. Ignoring score: "+ignoringScores);
     		//check if the reason applies
     		if (reason.check()) {
     			//if yes, add (new) posts to the list
@@ -176,6 +177,7 @@ public class PlagFinder {
     					if (existingMatch.getOriginal().getAnswerID() == id) {
     						//if it exists, add the new reason
     						alreadyExists = true;
+    						LOGGER.trace("Adding reason " + reason.description(i) + " with score " + scores.get(n));
     						existingMatch.addReason(reason.description(i), scores.get(n));
     						
     						existingMatch.addReasonToCopyPastorString(reason.description(i, false), scores.get(n));
@@ -190,6 +192,7 @@ public class PlagFinder {
     				if (!alreadyExists) {
     					PostMatch newMatch = new PostMatch(this.targetAnswer, post);
     					newMatch.addReason(reason.description(i), scores.get(n));
+    					LOGGER.trace("Adding PostMatch " + newMatch);
     					matches.add(newMatch);
     				}
     				

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -55,25 +55,25 @@ public class RelatedAnswersFinder {
             LOGGER.error("Could not load login.properties", e);
         }
         
-        LOGGER.info("Fetch the linked/related questions...");
+        LOGGER.debug("Fetching the linked/related questions...");
         
         try {
         	JsonObject relatedQuestions = ApiService.defaultService.getRelatedQuestionsByIds(idString);
-            LOGGER.info("Related done");
+            LOGGER.debug("Related done");
             JsonObject linkedQuestions = ApiService.defaultService.getLinkedQuestionsByIds(idString);
-            LOGGER.info("linked done");
+            LOGGER.debug("linked done");
             
             String relatedIds = "";
 
             for (JsonElement question : relatedQuestions.get("items").getAsJsonArray()) {
                 int id = question.getAsJsonObject().get("question_id").getAsInt();
-                //System.out.println("Add: "+id);
+                LOGGER.trace("Add: "+id);
                 relatedIds += id+";";
             }
             
             for (JsonElement question : linkedQuestions.get("items").getAsJsonArray()) {
                 int id = question.getAsJsonObject().get("question_id").getAsInt();
-                //System.out.println("Add: "+id);
+                LOGGER.trace("Add: "+id);
                 relatedIds += id+";";
             }
             
@@ -85,9 +85,9 @@ public class RelatedAnswersFinder {
                 int i = 1;
                 
                 while (i <= 2) {
-                	LOGGER.info("Fetch page "+i);
+                	LOGGER.debug("Fetch page "+i);
                 	JsonObject relatedAnswers = ApiService.defaultService.getAnswersToQuestionsByIdString(relatedIds, i);
-                    //System.out.println(relatedAnswers);
+                    LOGGER.trace("Related answers:\n" + relatedAnswers);
                     
                     for (JsonElement answer : relatedAnswers.get("items").getAsJsonArray()) {
                         JsonObject answerObject = answer.getAsJsonObject();
@@ -108,7 +108,7 @@ public class RelatedAnswersFinder {
                 	relatedPosts.add(post);
                 }
                                 
-                LOGGER.info("Collected "+relatedFinal.size()+" answers");
+                LOGGER.debug("Collected "+relatedFinal.size()+" answers");
                 
                 return relatedPosts;
             } else {

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -41,7 +41,7 @@ public class RelatedAnswersFinder {
             idString += n++ == 0 ? id : ";"+id;
         }
         
-        System.out.println(idString);
+        LOGGER.debug("Related IDs: " + idString);
         
         if (idString.length() < 2)
         	return new ArrayList<Post>();

--- a/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
+++ b/src/main/java/org/sobotics/guttenberg/printers/SoBoticsPostPrinter.java
@@ -1,18 +1,12 @@
 package org.sobotics.guttenberg.printers;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sobotics.guttenberg.clients.Guttenberg;
-import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.entities.PostMatch;
-import org.sobotics.guttenberg.utils.JsonUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 import org.sobotics.guttenberg.utils.PrintUtils;
-
-import com.google.gson.JsonObject;
 
 /**
  * Created by bhargav.h on 20-Oct-16.
@@ -36,6 +30,8 @@ public class SoBoticsPostPrinter implements PostPrinter {
 			reasonsList += reason+"; ";
 		}
 		
+		LOGGER.debug("PostPrinter reasons: " + reasonsList);
+		
 		String plagOrRepost = match.isRepost() ? "repost" : "plagiarism";
 		
 		double roundedTotalScore = Math.round(match.getTotalScore()*100.0)/100.0;
@@ -44,7 +40,7 @@ public class SoBoticsPostPrinter implements PostPrinter {
 			reportLink = PostUtils.storeReport(match);
 		}
 		catch (IOException e) {
-			LOGGER.warn(e.getMessage());
+			LOGGER.error("Error while sending the report to CopyPastor!", e);
 		}
 		
 		

--- a/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
@@ -36,6 +36,7 @@ public class ExactParagraphMatch implements Reason {
 	
 	@Override
 	public boolean check() {
+		LOGGER.trace("Checking for " + LABEL);
 		Properties prop = new Properties();
         try {
         	prop.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
@@ -49,9 +50,10 @@ public class ExactParagraphMatch implements Reason {
 		boolean matched = false;
 		
 		List<String> targetCodePs = PostUtils.getCodeParagraphs(this.target.getCleanBodyMarkdown());
-		//System.out.println(targetCodePs);
+		LOGGER.trace("Target code-only paragraphs: " + targetCodePs.size());
 		for (Post original : this.originals) {
 			List<String> originalCodePs = PostUtils.getCodeParagraphs(original.getCleanBodyMarkdown());
+			LOGGER.trace("Original code-only paragraphs: " + targetCodePs.size());
 			
 			//Loop through targetCodePs
 			for (String targetCode : targetCodePs) {
@@ -59,7 +61,7 @@ public class ExactParagraphMatch implements Reason {
 				for (String originalCode : originalCodePs) {
 					double similarity = jw.similarity(targetCode, originalCode);
 					if (similarity > 0.97 && originalCode.length() >= minimumLength && targetCode.length() >= minimumLength) {
-						System.out.println("Exact match: "+similarity+"\n"+targetCode);
+						LOGGER.debug("Exact match: "+similarity+"\n"+targetCode);
 						if (this.score < 0)
 							this.score = 0;
 						
@@ -86,7 +88,9 @@ public class ExactParagraphMatch implements Reason {
 	public String description(int index, boolean includingScore) {
 		if (includingScore) {
 			double roundedScore = Math.round(this.scoreList.get(index)*100.0)/100.0;
-			return score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+			String descriptionStr = score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+			LOGGER.trace("Description: " + descriptionStr);
+			return descriptionStr;
 		} else {
 			return LABEL;
 		}

--- a/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
@@ -41,6 +41,7 @@ public class StringSimilarity implements Reason {
 	}
 	
 	public static double similarityOf(Post targetPost, Post originalPost) {
+		LOGGER.debug("Checking StringSimilarity of " + targetPost.getAnswerID() + " and " + originalPost.getAnswerID());
 		String targetBodyMarkdown = targetPost.getCleanBodyMarkdown();
         String targetCodeOnly = targetPost.getCodeOnly();
         String targetPlaintext = targetPost.getPlaintext();
@@ -83,7 +84,7 @@ public class StringSimilarity implements Reason {
         double jwQuotes = originalQuotes != null ? ( jw.similarity(originalQuotes, targetQuotes)
         		* quantifierQuotes) : 0;
         
-        //LOGGER.info("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
+        LOGGER.debug("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
         
         double usedScores = (jwBodyMarkdown > 0 ? quantifierBodyMarkdown : 0)
         		+ (jwCodeOnly > 0 ? quantifierCodeOnly : 0)
@@ -94,7 +95,7 @@ public class StringSimilarity implements Reason {
         		+ (jwPlaintext > 0 ? jwPlaintext : 0)
         		+ (jwQuotes > 0 ? jwQuotes : 0)) / usedScores;
         
-        //LOGGER.info("Score: "+jaroWinklerScore);
+        LOGGER.debug("Score: "+jaroWinklerScore);
         
         if (jwBodyMarkdown > 0.9) {
         	return jwBodyMarkdown;
@@ -148,7 +149,9 @@ public class StringSimilarity implements Reason {
 	public String description(int index, boolean includingScore) {
 		if (includingScore) {
 			double roundedScore = Math.round(this.scoreList.get(index)*100.0)/100.0;
-			return score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+			String descriptionStr = score() >= 0 ? LABEL + " "+roundedScore : LABEL;
+			LOGGER.trace("Description: " + descriptionStr);
+			return descriptionStr;
 		} else {
 			return LABEL;
 		}

--- a/src/main/java/org/sobotics/guttenberg/services/RunnerService.java
+++ b/src/main/java/org/sobotics/guttenberg/services/RunnerService.java
@@ -128,6 +128,7 @@ public class RunnerService implements PingServiceDelegate {
     
     @Override
 	public void standbyStatusChanged(boolean newStatus) {
+    	LOGGER.info("New standby status: " + newStatus);
 		if (newStatus == false) {
 			StatusUtils.lastExecutionFinished = Instant.now();
 			StatusUtils.lastSucceededExecutionStarted = Instant.now().minusSeconds(30);

--- a/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FilePathUtils.java
@@ -3,6 +3,7 @@ package org.sobotics.guttenberg.utils;
 public class FilePathUtils {
 	public static String generalPropertiesFile = "./properties/general.properties";
     public static String loginPropertiesFile = "./properties/login.properties";
+    public static String loggerPropertiesFile = "./properties/logger.properties";
     public static String optedUsersFile = "./data/OptedInUsersList.txt";
     public static String blacklistedUsersFile = "./data/BlacklistedUsersList.txt";
 }

--- a/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/PostUtils.java
@@ -232,6 +232,12 @@ public class PostUtils {
 		}
 		
 		String url = prop.getProperty("copypastor_url", "http://localhost:5000")+"/posts/create";
+		
+		LOGGER.debug("Sending data to CopyPastor");
+		LOGGER.debug("CopyPastorURL: " + url);
+		LOGGER.debug("Score: " + match.getTotalScore());
+		LOGGER.debug("Reasons: " + match.getCopyPastorReasonString());
+		
 		JsonObject output = JsonUtils.post(url,
 						"key", prop.getProperty("copypastor_key", "no_key"),
 		                "url_one","//stackoverflow.com/a/"+target.getAnswerID(),
@@ -249,9 +255,7 @@ public class PostUtils {
 		                "score", ""+match.getTotalScore(),
 		                "reasons", match.getCopyPastorReasonString());
 		
-		LOGGER.debug("Sending data to CopyPastor");
-		LOGGER.debug("Score: " + match.getTotalScore());
-		LOGGER.debug("Reasons: " + match.getCopyPastorReasonString());
+		LOGGER.debug("Data sent to CopyPastor");
 		
 		return prop.getProperty("copypastor_url", "http://localhost:5000") + "/posts/" + output.get("post_id").getAsString();
 	}


### PR DESCRIPTION
Replaced (almost) all `System.out.println()` by `LOGGER.info()`. Additionally, more log-output with different levels has been added.

The log-level is saved in `properties/logger.properties`. ROs and moderators can change it with the new `log`-command. Usage: `log <instance> <error|warn|info|debug|trace>` (`instance` is not required. If not used, all instances will update their log-level)

---
closes #163