### PR TITLE
Bugfix/157 feedback url

### DIFF
--- a/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Feedback.java
@@ -55,9 +55,9 @@ public class Feedback implements SpecialCommand {
         }
         
         try {
-        	reportId = Integer.parseInt(word);
+        	reportId = CommandUtils.getPostIdFromUrl(word);
         } catch (Exception e) {
-        	LOGGER.info("Invalid report-ID", e);
+        	LOGGER.error("Report-URL could not be parsed!", e);
         }
         
         if (reportId == -1)

--- a/src/main/java/org/sobotics/guttenberg/utils/CommandUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/CommandUtils.java
@@ -4,6 +4,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +67,39 @@ public class CommandUtils {
             }
         }
         return word;
+    }
+    
+    /**
+     * Extracts the postId from a CopyPastor-URL
+     * @param input Input string
+     * @returns Post-ID
+     * @throws NumberFormatException if ID could not be read
+     * @throws IllegalArgumentException if the ID is <= 0
+     * */
+    public static int getPostIdFromUrl(String input) throws NumberFormatException, IllegalArgumentException {
+    	int postId = -1;
+    	LOGGER.debug("Checking string for postId: " + input);
+    	
+    	try {
+    		postId = Integer.parseInt(input);
+    	} catch (NumberFormatException e) {
+    		LOGGER.debug("Couldn't parse input to integer. Trying RegEx...");
+    		Pattern regex = Pattern.compile(".*\\/posts\\/(\\d*)");
+    		Matcher matcher = regex.matcher(input);
+    		
+    		if (matcher.matches()) {
+    			postId = Integer.parseInt(matcher.group(1));
+    		} else {
+    			throw new NumberFormatException("Could not extract postId from string '" + input + "'! RegEx didn't match.");
+    		}
+    	}
+    	
+    	if (postId > 0) {
+    		LOGGER.debug("Found postId: " + postId);
+    		return postId;
+    	} else {
+    		throw new IllegalArgumentException("Invalid postId!");
+    	}
     }
 
 }


### PR DESCRIPTION
The feedback-command now accepts URLs to CopyPastor as parameter. The ID will be extracted with RegEx


fixes #157 