### PR TITLE
Fix "Too many open files"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>de.felixsfd.stackoverflow</groupId>
 	<artifactId>guttenberg</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/org/sobotics/guttenberg/clients/Client.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Client.java
@@ -21,6 +21,7 @@ import org.sobotics.guttenberg.roomdata.SOBoticsChatRoom;
 import org.sobotics.guttenberg.roomdata.SOBoticsWorkshopChatRoom;
 import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 
 import fr.tunaki.stackoverflow.chat.StackExchangeClient;
@@ -40,7 +41,7 @@ public class Client {
     public static void main(String[] args) {
     	Properties loggerProperties = new Properties();
     	try{
-    		loggerProperties.load(new FileInputStream(FilePathUtils.loggerPropertiesFile));
+    		loggerProperties = FileUtils.getPropertiesFromFile(FilePathUtils.loggerPropertiesFile);
     		
     		String levelStr = loggerProperties.getProperty("level");
     		Level newLevel = Level.toLevel(levelStr, Level.ERROR);
@@ -58,7 +59,7 @@ public class Client {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             e.printStackTrace();

--- a/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
+++ b/src/main/java/org/sobotics/guttenberg/clients/Guttenberg.java
@@ -17,6 +17,7 @@ import org.sobotics.guttenberg.finders.PlagFinder;
 import org.sobotics.guttenberg.finders.RelatedAnswersFinder;
 import org.sobotics.guttenberg.printers.SoBoticsPostPrinter;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 
 import fr.tunaki.stackoverflow.chat.Room;
@@ -60,7 +61,7 @@ public class Guttenberg {
 		LOGGER.info("Starting Guttenberg.execute() ...");
 		
 		try {
-			props.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
+			props = FileUtils.getPropertiesFromFile(FilePathUtils.generalPropertiesFile);
 		} catch (IOException e) {
 			LOGGER.warn("Could not load general properties", e);
 		}

--- a/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
+++ b/src/main/java/org/sobotics/guttenberg/commandlists/SoBoticsCommandsList.java
@@ -127,7 +127,7 @@ public class SoBoticsCommandsList {
 		Properties prop = new Properties();
 
 		try {
-			prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+			prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
 			username = prop.getProperty("username").substring(0, 3).toLowerCase();
 		} catch (IOException e) {
 			LOGGER.error("Could not load login.properties", e);

--- a/src/main/java/org/sobotics/guttenberg/commands/Check.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Check.java
@@ -15,6 +15,7 @@ import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 
 import com.google.gson.JsonObject;
 
@@ -51,7 +52,7 @@ public class Check implements SpecialCommand {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("Could not read login.properties", e);

--- a/src/main/java/org/sobotics/guttenberg/commands/CheckInternet.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/CheckInternet.java
@@ -24,6 +24,7 @@ import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 import org.sobotics.guttenberg.utils.PrintUtils;
 
@@ -278,7 +279,7 @@ public class CheckInternet implements SpecialCommand {
 		Properties prop = new Properties();
 
 		try {
-			prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+			prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
 		} catch (IOException e) {
 			LOGGER.error("Could not read login.properties", e);
 			return;

--- a/src/main/java/org/sobotics/guttenberg/commands/CheckUser.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/CheckUser.java
@@ -20,6 +20,7 @@ import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.JsonUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 
@@ -217,7 +218,7 @@ public class CheckUser extends CheckInternet {
 		Properties prop = new Properties();
 
 		try {
-			prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+			prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
 		} catch (IOException e) {
 			LOGGER.error("Could not read login.properties", e);
 		}

--- a/src/main/java/org/sobotics/guttenberg/commands/LogLevel.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/LogLevel.java
@@ -2,6 +2,7 @@ package org.sobotics.guttenberg.commands;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Properties;
 
 import org.apache.log4j.Level;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.services.RunnerService;
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.redunda.PingService;
 
 import fr.tunaki.stackoverflow.chat.Message;
@@ -83,14 +85,29 @@ public class LogLevel implements SpecialCommand {
         	//the logging-level for this instance should be changed
         	Level newLevel = Level.toLevel(levelString);
         	LogManager.getRootLogger().setLevel(newLevel);
+        	FileOutputStream fOut = null;
         	
         	try {
         		Properties loggingProp = new Properties();
-        		loggingProp.load(new FileInputStream(FilePathUtils.loggerPropertiesFile));
+        		loggingProp = FileUtils.getPropertiesFromFile(FilePathUtils.loggerPropertiesFile);
         		loggingProp.setProperty("level", levelString.toLowerCase());
-        		loggingProp.store(new FileOutputStream(FilePathUtils.loggerPropertiesFile), null);
+        		
+        		fOut = new FileOutputStream(FilePathUtils.loggerPropertiesFile);
+        		
+        		loggingProp.store(fOut, null);
+        		
+        		fOut.close();
         	} catch (Exception e) {
         		LOGGER.error("Error while saving the new log-level to the logging.properties", e);
+        	}
+        	finally {
+        		if (fOut != null) {
+        			try {
+						fOut.close();
+					} catch (IOException e) {
+						LOGGER.error("Could not close FileOutputStream!", e);
+					}
+        		}
         	}
         	
         	LOGGER.info("Logging-level successfully changed to " + levelString);

--- a/src/main/java/org/sobotics/guttenberg/commands/Quota.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Quota.java
@@ -2,6 +2,7 @@ package org.sobotics.guttenberg.commands;
 
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 import org.sobotics.redunda.PingService;
 
@@ -36,7 +37,7 @@ public class Quota implements SpecialCommand {
     	Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("Error: ", e);

--- a/src/main/java/org/sobotics/guttenberg/commands/Status.java
+++ b/src/main/java/org/sobotics/guttenberg/commands/Status.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.utils.CommandUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 import org.sobotics.redunda.PingService;
 import org.sobotics.guttenberg.services.RunnerService;
@@ -37,9 +38,10 @@ public class Status implements SpecialCommand {
         Properties prop2 = new Properties();
         
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
             InputStream is = Status.class.getResourceAsStream("/guttenberg.properties");
                prop2.load(is);
+               is.close();
         }
         catch (IOException e){
             LOGGER.error("Could not load properties", e);

--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -10,6 +10,7 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 
 /**
  * Represents a plagiarized post
@@ -90,7 +91,7 @@ public class PostMatch implements Comparable<PostMatch>{
 		int minimumLength = 200;
 		Properties quantifiers = new Properties();
         try {
-        	quantifiers.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
+        	quantifiers = FileUtils.getPropertiesFromFile(FilePathUtils.generalPropertiesFile);
         	minimumLength = new Integer(quantifiers.getProperty("minimumPostLength", "200"));
         } catch (Throwable e) {
         	LOGGER.warn("Could not load quantifiers from general.properties. Using hardcoded", e);

--- a/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/NewAnswersFinder.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.services.ApiService;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 
@@ -38,7 +39,7 @@ public class NewAnswersFinder {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("Could not load login.properties", e);

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -16,6 +16,7 @@ import org.sobotics.guttenberg.reasons.Reason;
 import org.sobotics.guttenberg.services.ApiService;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 
 import com.google.gson.JsonElement;
@@ -69,7 +70,7 @@ public class PlagFinder {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("Could not load login.properties", e);

--- a/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/RelatedAnswersFinder.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.services.ApiService;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 
 import com.google.gson.JsonElement;
@@ -49,7 +50,7 @@ public class RelatedAnswersFinder {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("Could not load login.properties", e);

--- a/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/ExactParagraphMatch.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.PostUtils;
 
 import info.debatty.java.stringsimilarity.JaroWinkler;
@@ -39,7 +40,7 @@ public class ExactParagraphMatch implements Reason {
 		LOGGER.trace("Checking for " + LABEL);
 		Properties prop = new Properties();
         try {
-        	prop.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
+        	prop = FileUtils.getPropertiesFromFile(FilePathUtils.generalPropertiesFile);
         } catch (IOException e) {
         	LOGGER.warn("Could not load general.properties. Using hardcoded value", e);
         }

--- a/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.entities.Post;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 
 import info.debatty.java.stringsimilarity.JaroWinkler;
 
@@ -49,7 +50,7 @@ public class StringSimilarity implements Reason {
         
         Properties quantifiers = new Properties();
         try {
-        	quantifiers.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
+        	quantifiers = FileUtils.getPropertiesFromFile(FilePathUtils.generalPropertiesFile);
         } catch (IOException e) {
         	LOGGER.warn("Could not load quantifiers from general.properties. Using hardcoded", e);
         }
@@ -117,7 +118,7 @@ public class StringSimilarity implements Reason {
 			//get the report threshold
 			Properties prop = new Properties();
 	        try {
-	        	prop.load(new FileInputStream(FilePathUtils.generalPropertiesFile));
+	        	prop = FileUtils.getPropertiesFromFile(FilePathUtils.generalPropertiesFile);
 	        } catch (IOException e) {
 	        	LOGGER.warn("Could not load general.properties. Using hardcoded value", e);
 	        }

--- a/src/main/java/org/sobotics/guttenberg/services/ApiService.java
+++ b/src/main/java/org/sobotics/guttenberg/services/ApiService.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.utils.ApiUtils;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.JsonUtils;
 
 import com.google.gson.JsonObject;
@@ -35,7 +36,7 @@ public class ApiService {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             e.printStackTrace();

--- a/src/main/java/org/sobotics/guttenberg/services/RunnerService.java
+++ b/src/main/java/org/sobotics/guttenberg/services/RunnerService.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.sobotics.guttenberg.clients.Guttenberg;
 import org.sobotics.guttenberg.roomdata.BotRoom;
 import org.sobotics.guttenberg.utils.FilePathUtils;
+import org.sobotics.guttenberg.utils.FileUtils;
 import org.sobotics.guttenberg.utils.StatusUtils;
 import org.sobotics.redunda.PingService;
 import org.sobotics.redunda.PingServiceDelegate;
@@ -43,7 +44,7 @@ public class RunnerService implements PingServiceDelegate {
     public void start() {
     	Properties prop = new Properties();
     	try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
         }
         catch (IOException e){
             LOGGER.error("login.properties could not be loaded!", e);

--- a/src/main/java/org/sobotics/guttenberg/utils/CommandUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/CommandUtils.java
@@ -23,7 +23,7 @@ public class CommandUtils {
         Properties prop = new Properties();
 
         try{
-            prop.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+            prop = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
             username = prop.getProperty("username").substring(0,3).toLowerCase();
         }
         catch (IOException e){
@@ -87,7 +87,7 @@ public class CommandUtils {
     		Properties props = new Properties();
     		
     		try {
-    			props.load(new FileInputStream(FilePathUtils.loginPropertiesFile));
+    			props = FileUtils.getPropertiesFromFile(FilePathUtils.loginPropertiesFile);
     			
     			String cpUrl = props.getProperty("copypastor_url");
     			

--- a/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
@@ -1,6 +1,7 @@
 package org.sobotics.guttenberg.utils;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,13 +10,19 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Scanner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by bhargav.h on 30-Sep-16.
  */
 public class FileUtils {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
     public static void appendToFile(String filename, String word) throws IOException{
         Files.write(Paths.get(filename), Arrays.asList(word), StandardOpenOption.APPEND, StandardOpenOption.WRITE);
@@ -125,4 +132,32 @@ public class FileUtils {
 
        return result;      
     }
+    
+    /**
+     * Loads the properties from a file and closes the FileInputStream
+     * @param filepath Path to the .properties file
+     * @return Properties
+     * @throws IOException
+     */
+    public static Properties getPropertiesFromFile(String filepath) throws IOException {
+    	Properties prop;
+    	
+    	LOGGER.debug("Trying to load file " + filepath + " to properties...");
+    	FileInputStream fis = new FileInputStream(filepath);
+    	LOGGER.trace("FileInputStream opened");
+    	
+		try {
+			prop = new Properties();
+			prop.load(fis);
+			LOGGER.debug("Succesffully loaded");
+		} //try
+		finally {
+			if (fis != null) {
+				fis.close();
+				LOGGER.trace("Closed FileInputStream");
+			}
+		} // try-finally
+    	
+    	return prop;
+    } // getPropertiesFromFile
 }


### PR DESCRIPTION
When reading the properties, the `FileInputStream` wasn't closed correctly. This should now be fixed by using this new method in `FileUtils`:

    public static Properties getPropertiesFromFile(String filepath) throws IOException {
        Properties prop;
        
        LOGGER.debug("Trying to load file " + filepath + " to properties...");
        FileInputStream fis = new FileInputStream(filepath);
        LOGGER.trace("FileInputStream opened");
        
        try {
            prop = new Properties();
            prop.load(fis);
            LOGGER.debug("Succesffully loaded");
        } //try
        finally {
            if (fis != null) {
                fis.close();
                LOGGER.trace("Closed FileInputStream");
            }
        } // try-finally
        
        return prop;
    }

--
fix #170 