### PR TITLE
Hotfix/176 reason string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>de.felixsfd.stackoverflow</groupId>
 	<artifactId>guttenberg</artifactId>
-	<version>1.2.1</version>
+	<version>1.2.2</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
+++ b/src/main/java/org/sobotics/guttenberg/entities/PostMatch.java
@@ -47,18 +47,22 @@ public class PostMatch implements Comparable<PostMatch>{
 		}
 	}
 	
+	/**
+	 * Adds the reason to the String sent to CopyPastor
+	 * (can't be called by addReason() because this would include the score in the description)
+	 * */
 	public void addReasonToCopyPastorString(String reason, double score) {
-		LOGGER.trace("Adding reason \"" + reason + "\" (Score: " + score + ") to string for CopyPastor");
+		LOGGER.debug("Adding reason \"" + reason + "\" (Score: " + score + ") to string for CopyPastor");
 		//#171: don't check the array. Check the String instead
 		if (!copyPastorReasonString.contains(reason)) {
-			LOGGER.trace("Reason doesn't exist in string yet");
+			LOGGER.debug("Reason doesn't exist in string yet");
 			double roundedScore = Math.round(score*100.0)/100.0;
 			
 			if (copyPastorReasonString.length() > 0)
 				this.copyPastorReasonString += ",";
 			
 			this.copyPastorReasonString += reason + ":" + roundedScore;
-			LOGGER.trace("New copyPastorReasonString: " + this.copyPastorReasonString);
+			LOGGER.debug("New copyPastorReasonString: " + this.copyPastorReasonString);
 		}
 	}
 	

--- a/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
+++ b/src/main/java/org/sobotics/guttenberg/finders/PlagFinder.java
@@ -178,7 +178,7 @@ public class PlagFinder {
     					if (existingMatch.getOriginal().getAnswerID() == id) {
     						//if it exists, add the new reason
     						alreadyExists = true;
-    						LOGGER.trace("Adding reason " + reason.description(i) + " with score " + scores.get(n));
+    						LOGGER.debug("Adding reason " + reason.description(i) + " with score " + scores.get(n));
     						existingMatch.addReason(reason.description(i), scores.get(n));
     						
     						existingMatch.addReasonToCopyPastorString(reason.description(i, false), scores.get(n));
@@ -193,6 +193,8 @@ public class PlagFinder {
     				if (!alreadyExists) {
     					PostMatch newMatch = new PostMatch(this.targetAnswer, post);
     					newMatch.addReason(reason.description(i), scores.get(n));
+    					//#176: add the reason to the string for CopyPastor as well
+    					newMatch.addReasonToCopyPastorString(reason.description(i, false), scores.get(n));
     					LOGGER.trace("Adding PostMatch " + newMatch);
     					matches.add(newMatch);
     				}

--- a/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
+++ b/src/main/java/org/sobotics/guttenberg/reasons/StringSimilarity.java
@@ -85,7 +85,7 @@ public class StringSimilarity implements Reason {
         double jwQuotes = originalQuotes != null ? ( jw.similarity(originalQuotes, targetQuotes)
         		* quantifierQuotes) : 0;
         
-        LOGGER.debug("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
+        LOGGER.trace("bodyMarkdown: "+jwBodyMarkdown+"; codeOnly: "+jwCodeOnly+"; plaintext: "+jwPlaintext);
         
         double usedScores = (jwBodyMarkdown > 0 ? quantifierBodyMarkdown : 0)
         		+ (jwCodeOnly > 0 ? quantifierCodeOnly : 0)
@@ -96,7 +96,7 @@ public class StringSimilarity implements Reason {
         		+ (jwPlaintext > 0 ? jwPlaintext : 0)
         		+ (jwQuotes > 0 ? jwQuotes : 0)) / usedScores;
         
-        LOGGER.debug("Score: "+jaroWinklerScore);
+        LOGGER.trace("Score: "+jaroWinklerScore);
         
         if (jwBodyMarkdown > 0.9) {
         	return jwBodyMarkdown;

--- a/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
+++ b/src/main/java/org/sobotics/guttenberg/utils/FileUtils.java
@@ -149,7 +149,7 @@ public class FileUtils {
 		try {
 			prop = new Properties();
 			prop.load(fis);
-			LOGGER.debug("Succesffully loaded");
+			LOGGER.trace("Succesffully loaded");
 		} //try
 		finally {
 			if (fis != null) {


### PR DESCRIPTION
Although it looked like the same bug, we had before, but it was different. I just forgot to add the reason to the CopyPastor-String, if the `PostMatch` existed yet.

See `PlagFinder.matchesForReasons()`

----
fixes #176 